### PR TITLE
Support syntax highlight in hover fenced blocks

### DIFF
--- a/src/rescript-editor-support/Hover.re
+++ b/src/rescript-editor-support/Hover.re
@@ -36,7 +36,7 @@ let showModuleTopLevel =
        )
     |> String.concat("\n");
   let full = "module " ++ name ++ " = {" ++ "\n" ++ contents ++ "\n}";
-  Some(markdown ? "```\n" ++ full ++ "\n```" : full);
+  Some(markdown ? "```rescript\n" ++ full ++ "\n```" : full);
 };
 
 let showModule =
@@ -114,7 +114,8 @@ let newHover =
       /* Some(typ.toString()) */
     };
 
-    let codeBlock = text => markdown ? "```\n" ++ text ++ "\n```" : text;
+    let codeBlock = text =>
+      markdown ? "```rescript\n" ++ text ++ "\n```" : text;
     let typeString = codeBlock(typeString);
     let typeString =
       typeString


### PR DESCRIPTION
This make it possible for clients to use correct syntax highlighting in hovers.

Vim example:

![image](https://user-images.githubusercontent.com/13261088/99880749-8cf44780-2c2a-11eb-87ad-c2af846a48af.png)

![image](https://user-images.githubusercontent.com/13261088/99880758-98477300-2c2a-11eb-843c-287e910db981.png)


