### PR TITLE
Always output valid json, even in case of internal error.

### DIFF
--- a/src/rescript-editor-support/EditorSupportCommands.re
+++ b/src/rescript-editor-support/EditorSupportCommands.re
@@ -101,7 +101,7 @@ let dumpLocations = (state, ~package, ~file, ~extra, ~selectPos, uri) => {
        })
     |> l;
 
-  print_endline(Json.stringify(locationsInfo));
+  Json.stringify(locationsInfo);
 };
 
 let dump = files => {
@@ -129,11 +129,15 @@ let dump = files => {
          };
        let filePath = maybeConcat(Unix.getcwd(), filePath);
        let uri = Utils.toUri(filePath);
-       switch (State.getFullFromCmt(uri, state)) {
-       | Error(message) => print_endline(message)
-       | Ok((package, {file, extra})) =>
-         dumpLocations(state, ~package, ~file, ~extra, ~selectPos, uri)
-       };
+       let result =
+         switch (State.getFullFromCmt(uri, state)) {
+         | Error(message) =>
+           prerr_endline(message);
+           "[]";
+         | Ok((package, {file, extra})) =>
+           dumpLocations(state, ~package, ~file, ~extra, ~selectPos, uri)
+         };
+       print_endline(result);
      });
 };
 
@@ -222,7 +226,7 @@ let autocomplete = (~currentFile, ~full, ~package, ~pos, ~state) => {
            })
         |> l;
 
-  print_endline(Json.stringify(completions));
+  Json.stringify(completions);
 };
 
 let complete = (~pathWithPos, ~currentFile) => {
@@ -242,12 +246,16 @@ let complete = (~pathWithPos, ~currentFile) => {
     let pos = (line |> int_of_string, char |> int_of_string);
     let filePath = maybeConcat(Unix.getcwd(), filePath);
     let uri = Utils.toUri(filePath);
-    switch (State.getFullFromCmt(uri, state)) {
-    | Error(message) => print_endline(message)
-    | Ok((package, full)) =>
-      Hashtbl.replace(state.lastDefinitions, uri, full);
-      autocomplete(~currentFile, ~full, ~package, ~pos, ~state);
-    };
+    let result =
+      switch (State.getFullFromCmt(uri, state)) {
+      | Error(message) =>
+        prerr_endline(message);
+        "[]";
+      | Ok((package, full)) =>
+        Hashtbl.replace(state.lastDefinitions, uri, full);
+        autocomplete(~currentFile, ~full, ~package, ~pos, ~state);
+      };
+    print_endline(result);
   | _ => ()
   };
 };

--- a/src/rescript-editor-support/Pretty.ml
+++ b/src/rescript-editor-support/Pretty.ml
@@ -79,12 +79,6 @@ let text ?len string =
     single_line = true;
   }
 
-let print_indentation n =
-  print_char '\n';
-  for _ = 1 to n do
-  print_char ' ';
-  done
-
 let rec flatten doc =
   match doc.node with
     | Append (a, b) -> append (flatten a) (flatten b)
@@ -118,8 +112,8 @@ let push offset node (stack: stack) =
 
 let print
     ?width:(width=70)
-    ?output:(output=print_string)
-    ?indent:(indent=print_indentation)
+    ~output
+    ~indent
     doc =
   let rec loop currentIndent stack =
     match stack with

--- a/src/rescript-editor-support/Pretty.mli
+++ b/src/rescript-editor-support/Pretty.mli
@@ -51,7 +51,7 @@ val back : int -> string -> doc
     "indent" function that defines how to print a newline and indent
     to a desired level.  The default arguments print to stdout. *)
 val print : ?width: int ->
-  ?output: (string -> unit) ->
-  ?indent: (int -> unit) ->
+  output: (string -> unit) ->
+  indent: (int -> unit) ->
   doc ->
   unit

--- a/src/rescript-editor-support/vendor/omd/omd_parser.ml
+++ b/src/rescript-editor-support/vendor/omd/omd_parser.ml
@@ -154,24 +154,6 @@ struct
       extraction a portion of another lexing tree. *)
   let fix l =
     let rec loop accu = function
-      (* code to generate what follows...
-         List.iter (fun e ->
-         Printf.printf "
-         | %s::%s::tl ->
-            if trackfix then eprintf \"%s 1\\n%!\";
-            loop accu (%ss 0::tl)
-         | %ss n::%s::tl ->
-            if trackfix then eprintf \"%s 2\\n%!\";
-            loop accu (%ss(n+1)::tl)
-         | %s::%ss n::tl ->
-            if trackfix then eprintf \"%s 3\\n%!\";
-            loop accu (%ss(n+1)::tl)
-         | %ss a::%ss b::tl ->
-            if trackfix then eprintf \"%s 4\\n%!\";
-            loop accu (%ss(a+b+2)::tl)"
-         e e e e e e e e e e e e e e e e)
-         ["Ampersand"; "At"; "Backquote"; "Backslash"; "Bar"; "Caret"; "Cbrace"; "Colon"; "Comma"; "Cparenthesis"; "Cbracket"; "Dollar"; "Dot"; "Doublequote"; "Exclamation"; "Equal"; "Greaterthan"; "Hash"; "Lessthan"; "Minus"; "Newline"; "Obrace"; "Oparenthesis"; "Obracket"; "Percent"; "Plus"; "Question"; "Quote"; "Semicolon"; "Slash"; "Space"; "Star"; "Tab"; "Tilde"; "Underscore"];
-         print_string "| x::tl -> loop (x::accu) tl\n| [] -> List.rev accu\n"; *)
       | Ampersand::Ampersand::tl ->
         if trackfix then eprintf "(OMD) Ampersand 1\n";
         loop accu (Ampersands 0::tl)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-editor-support/issues/19

Suppress all printing to stdout.
Print `[]` in case of internal error. For examople, if the project was never built, or a file cannot be built for the first time because of syntax errors. In that case, there's an internal error as the `.cmt` cannot be found.