### PR TITLE
Fix issue in command-line parsing on Windows with paths of the form `…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@
 - Support syntax highlight in hover fenced blocks.
 - Fix printing of variant arguments.
 - Use outcome printer from the syntax to print type declarations.
+- Fix issue in command-line parsing on Windows with paths of the form `c:/...:line:column`.
 
 ## Release 1.0.0 of rescript-vscode 
 This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/d45f45793a307a3bb87dcac0542fd412669f1b6e) is vendored in [rescript-vscode 1.0.0](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.0).


### PR DESCRIPTION
…c:/...:line:column`

See https://github.com/rescript-lang/rescript-vscode/issues/25