### PR TITLE
Fix issue where type variables are printed with global renaming when …

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,5 @@
 ## master
+- Fix issue where type variables are printed with global renaming when hovering or autocompleting a module (see https://github.com/rescript-lang/rescript-editor-support/issues/38).
 
 ## Release 1.0.1 of rescript-vscode 
 This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/232ad609766c415048750c5cc828973a9995f382) is vendored in [rescript-vscode 1.0.1](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.1).

--- a/src/rescript-editor-support/PrintType.re
+++ b/src/rescript-editor-support/PrintType.re
@@ -1,4 +1,5 @@
 let printExpr = typ => {
+  Printtyp.reset_names();
   Res_doc.toString(
     ~width=60,
     Res_outcome_printer.printOutTypeDoc(Printtyp.tree_of_typexp(false, typ)),
@@ -6,6 +7,7 @@ let printExpr = typ => {
 };
 
 let printDecl = (~recStatus, name, decl) => {
+  Printtyp.reset_names();
   Res_doc.toString(
     ~width=60,
     Res_outcome_printer.printOutSigItemDoc(


### PR DESCRIPTION
…hovering or autocompleting a module

Fixes https://github.com/rescript-lang/rescript-editor-support/issues/38.

Turns out `Printtyp` keeps global state when converting to outcome printer data structures.
Reses the data before converting types to strings.