### PR TITLE
Fix wrong types for nested record fields

### DIFF
--- a/src/rescript-editor-support/Hover.re
+++ b/src/rescript-editor-support/Hover.re
@@ -152,7 +152,11 @@ let newHover = (~rootUri, ~file: SharedTypes.file, ~getModule, loc) => {
               ),
               docstring,
             ]
-          | `Attribute(_) => [Some(typeString), docstring]
+          | `Attribute({typ}) => [
+              // TODO: show complete type def
+              Some(Shared.typeToString(typ)),
+              docstring,
+            ]
           };
 
         let parts = parts @ [Some(uri)];


### PR DESCRIPTION
This is a temporarily fix for https://github.com/rescript-lang/rescript-vscode/issues/52