### PR TITLE
Fix hovering on record fields.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,5 @@
 ## master
+- Fix type shown when hovering on record fields (see https://github.com/rescript-lang/rescript-vscode/issues/52), and doc comments for records.
 - Fix issue where type variables are printed with global renaming when hovering or autocompleting a module (see https://github.com/rescript-lang/rescript-editor-support/issues/38).
 - Fix issue where a log file was always created (see https://github.com/rescript-lang/rescript-vscode/issues/47).
 - Add support for hover on the id of toplevel module definitions (```module Id = ...```).

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -77,3 +77,8 @@ let testRecordFields = (gr: gr) => {
   let str = gr.s
   str
 }
+
+@ocaml.doc("vr docstring")
+type vr = | V1 | V2
+
+let v1 = V1

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -38,22 +38,20 @@ type inline =
   | E({x: int, y: string})
   | F
 
-module MSig
-: {
-  type rec t = | A (list<s>)
+module MSig: {
+  type rec t = A(list<s>)
   and s = list<t>
 
-  let x : int
-} 
-= {
-  type rec t = | A (list<s>)
+  let x: int
+} = {
+  type rec t = A(list<s>)
   and s = list<t>
 
   let x = 14
 }
 
 module Impl = {
-  type rec t = | A (list<s>)
+  type rec t = A(list<s>)
   and s = list<t>
 
   type w = int
@@ -61,8 +59,21 @@ module Impl = {
   let x = 14
 }
 
-module Impl2 = { include Impl};
+module Impl2 = {
+  include Impl
+}
 
 module D = MSig
 module E = Impl
 module F = Impl2
+
+@ocaml.doc("str docstring")
+type str = string
+
+@ocaml.doc("gr docstring")
+type gr = {x: int, s: str}
+
+let testRecordFields = (gr: gr) => {
+  let str = gr.s
+  str
+}

--- a/src/rescript-editor-support/References.re
+++ b/src/rescript-editor-support/References.re
@@ -86,15 +86,11 @@ let definedForLoc = (~file, ~getModule, locKind) => {
   let inner = (~file, stamp, tip) => {
     switch (tip) {
     | Constructor(name) =>
-      let%opt declared =
-        Query.declaredForTip(~stamps=file.stamps, stamp, tip);
       let%opt constructor = Query.getConstructor(file, stamp, name);
-      Some((declared.docstring, file, `Constructor(constructor)));
+      Some((None, file, `Constructor(constructor)));
     | Attribute(name) =>
-      let%opt declared =
-        Query.declaredForTip(~stamps=file.stamps, stamp, tip);
       let%opt attribute = Query.getAttribute(file, stamp, name);
-      Some((declared.docstring, file, `Attribute(attribute)));
+      Some((None, file, `Attribute(attribute)));
     | _ =>
       maybeLog(
         "Trying for declared "
@@ -104,8 +100,8 @@ let definedForLoc = (~file, ~getModule, locKind) => {
         ++ " in file "
         ++ file.uri,
       );
-      let%opt x = Query.declaredForTip(~stamps=file.stamps, stamp, tip);
-      Some((x.docstring, file, `Declared));
+      let%opt declared = Query.declaredForTip(~stamps=file.stamps, stamp, tip);
+      Some((declared.docstring, file, `Declared));
     };
   };
 


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/52

Continuation of https://github.com/rescript-lang/rescript-editor-support/pull/47

Show the correct type information, including type definition for record fields.
Also, fix issue in the docstring shown. Before it was either misssing (entire record type) or wrong (for record field, it was showing the doc comment of the containing record type).
Clean up code in References.