### PR TITLE
Fix jump to type definition for types defined in an inner module.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 - Fix autocomplete issue where `open Foo` would be picked up inside line comments (see https://github.com/rescript-lang/rescript-editor-support/issues/15).
 - Don't print parens as in `A()` for 0-ary variants.
 - Fix infinite loop in autocomplete that can cause `rescript-editor-support.exe` processes to use up 100% cpu.
+- Fix jump to type definition for types defined in an inner module.
 
 ## Release 1.0.3 of rescript-vscode 
 This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/214d220d8573f9f0c8d54e623c163e01617bf124) is vendored in [rescript-vscode 1.0.3](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.3).

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -86,3 +86,12 @@ let v1 = V1
 module DoubleNested = ModuleWithDocComment.Nested.NestedAgain
 
 let uncurried = (. x) => x+1;
+
+module Inner = {
+  type tInner = int;
+  let vInner = 34
+}
+
+type typeInner = Inner.tInner;
+
+let valueInner = Inner.vInner;

--- a/src/rescript-editor-support/ProcessExtra.re
+++ b/src/rescript-editor-support/ProcessExtra.re
@@ -144,7 +144,12 @@ module F =
         addExternalReference(moduleName, path, tip, identLoc);
         GlobalReference(moduleName, path, tip);
       | `Exported(env, name) =>
-        switch (Hashtbl.find_opt(env.exported.values, name)) {
+        switch (
+          Hashtbl.find_opt(
+            tip == Type ? env.exported.types : env.exported.values,
+            name,
+          )
+        ) {
         | Some(stamp) =>
           addReference(stamp, identLoc);
           LocalReference(stamp, tip);
@@ -230,12 +235,7 @@ module F =
                | None => NotFound
                }
              | `Global(moduleName, path) =>
-               addExternalReference(
-                 moduleName,
-                 path,
-                 Field(name),
-                 nameLoc,
-               );
+               addExternalReference(moduleName, path, Field(name), nameLoc);
                GlobalReference(moduleName, path, Field(name));
              | _ => NotFound
              };


### PR DESCRIPTION
Fix cross-reference for type definitions belonging to an inner module. The lookup used to search values instead of types.

Fixes https://github.com/rescript-lang/rescript-editor-support/issues/54