### PR TITLE
Explore autocomplete for pipe-first.

### DIFF
--- a/src/rescript-editor-support/Hover.re
+++ b/src/rescript-editor-support/Hover.re
@@ -78,7 +78,7 @@ let newHover = (~rootUri, ~file: SharedTypes.file, ~getModule, loc) => {
     showModule(~docstring, ~name, ~file, declared);
   | LModule(GlobalReference(moduleName, path, tip)) =>
     let%opt file = getModule(moduleName);
-    let env = {Query.file, exported: file.contents.exported};
+    let env = Query.fileEnv(file);
     let%opt (env, name) = Query.resolvePath(~env, ~path, ~getModule);
     let%opt stamp = Query.exportedForTip(~env, name, tip);
     let%opt md = Hashtbl.find_opt(file.stamps.modules, stamp);
@@ -116,7 +116,7 @@ let newHover = (~rootUri, ~file: SharedTypes.file, ~getModule, loc) => {
     let fromType = (~docstring, typ) => {
       let typeString = codeBlock(typ |> Shared.typeToString);
       let extraTypeInfo = {
-        let env = {Query.file, exported: file.contents.exported};
+        let env = Query.fileEnv(file);
         let%opt path = typ |> Shared.digConstructor;
         let%opt (_env, {docstring, name: {txt}, item: {decl}}) =
           digConstructor(~env, ~getModule, path);

--- a/src/rescript-editor-support/NewCompletions.re
+++ b/src/rescript-editor-support/NewCompletions.re
@@ -588,7 +588,7 @@ let mkItem = (~name, ~kind, ~detail, ~docstring, ~uri, ~pos_lnum) => {
           J.s(
             (docstring |? "No docs")
             ++ "\n\n"
-            ++ uri
+            ++ Uri2.toString(uri)
             ++ ":"
             ++ string_of_int(pos_lnum),
           ),

--- a/src/rescript-editor-support/ProcessExtra.re
+++ b/src/rescript-editor-support/ProcessExtra.re
@@ -123,10 +123,7 @@ module F =
       ],
     );
   };
-  let env = {
-    Query.file: Collector.file,
-    exported: Collector.file.contents.exported,
-  };
+  let env = Query.fileEnv(Collector.file);
 
   let getTypeAtPath = getTypeAtPath(~env);
 

--- a/src/rescript-editor-support/Query.re
+++ b/src/rescript-editor-support/Query.re
@@ -1,7 +1,5 @@
 open SharedTypes;
 
-/* TODO maybe keep track of the "current module path" */
-/* maybe add a "current module path" for debugging purposes */
 type queryEnv = {
   file,
   exported,
@@ -111,11 +109,7 @@ let rec resolvePath = (~env, ~path, ~getModule) => {
   | `Local(env, name) => Some((env, name))
   | `Global(moduleName, fullPath) =>
     let%opt file = getModule(moduleName);
-    resolvePath(
-      ~env={file, exported: file.contents.exported},
-      ~path=fullPath,
-      ~getModule,
-    );
+    resolvePath(~env=fileEnv(file), ~path=fullPath, ~getModule);
   };
 };
 
@@ -131,11 +125,7 @@ let resolveFromStamps = (~env, ~path, ~getModule, ~pos) => {
     | `Local(env, name) => Some((env, name))
     | `Global(moduleName, fullPath) =>
       let%opt file = getModule(moduleName);
-      resolvePath(
-        ~env={file, exported: file.contents.exported},
-        ~path=fullPath,
-        ~getModule,
-      );
+      resolvePath(~env=fileEnv(file), ~path=fullPath, ~getModule);
     };
   };
 };
@@ -192,7 +182,7 @@ let resolveFromCompilerPath = (~env, ~getModule, path) => {
       switch (getModule(moduleName)) {
       | None => None
       | Some(file) =>
-        let env = {file, exported: file.contents.exported};
+        let env = fileEnv(file);
         resolvePath(~env, ~getModule, ~path);
       };
     switch (res) {

--- a/src/rescript-editor-support/References.re
+++ b/src/rescript-editor-support/References.re
@@ -115,7 +115,7 @@ let definedForLoc = (~file, ~getModule, locKind) => {
       let%try file =
         getModule(moduleName)
         |> RResult.orError("Cannot get module " ++ moduleName);
-      let env = {Query.file, exported: file.contents.exported};
+      let env = Query.fileEnv(file);
       let%try (env, name) =
         Query.resolvePath(~env, ~path, ~getModule)
         |> RResult.orError("Cannot resolve path " ++ pathToString(path));
@@ -176,7 +176,7 @@ let resolveModuleReference =
   switch (declared.item) {
   | Structure(_) => Some((file, Some(declared)))
   | Ident(path) =>
-    let env = {Query.file, exported: file.contents.exported};
+    let env = Query.fileEnv(file);
     switch (Query.fromCompilerPath(~env, path)) {
     | `Not_found => None
     | `Exported(env, name) =>
@@ -186,7 +186,7 @@ let resolveModuleReference =
     /* Some((env.file.uri, validateLoc(md.name.loc, md.extentLoc))) */
     | `Global(moduleName, path) =>
       let%opt file = getModule(moduleName);
-      let env = {file, Query.exported: file.contents.exported};
+      let env = Query.fileEnv(file);
       let%opt (env, name) = Query.resolvePath(~env, ~getModule, ~path);
       let%opt stamp = Hashtbl.find_opt(env.exported.modules, name);
       let%opt md = Hashtbl.find_opt(env.file.stamps.modules, stamp);
@@ -217,7 +217,7 @@ let forLocalStamp =
       stamp,
       tip,
     ) => {
-  let env = {Query.file, exported: file.contents.exported};
+  let env = Query.fileEnv(file);
   open Infix;
   let%opt localStamp =
     switch (tip) {
@@ -365,7 +365,7 @@ let allReferencesForLoc =
     let%try file =
       getModule(moduleName)
       |> RResult.orError("Cannot get module " ++ moduleName);
-    let env = {Query.file, exported: file.contents.exported};
+    let env = Query.fileEnv(file);
     let%try (env, name) =
       Query.resolvePath(~env, ~path, ~getModule)
       |> RResult.orError("Cannot resolve path " ++ pathToString(path));
@@ -512,7 +512,7 @@ let definitionForLoc = (~pathsForModule, ~file, ~getUri, ~getModule, loc) => {
       ++ tipToString(tip),
     );
     let%opt file = getModule(moduleName);
-    let env = {Query.file, exported: file.contents.exported};
+    let env = Query.fileEnv(file);
     let%opt (env, name) = Query.resolvePath(~env, ~path, ~getModule);
     let%opt stamp = Query.exportedForTip(~env, name, tip);
     /** oooh wht do I do if the stamp is inside a pseudo-file? */

--- a/src/rescript-editor-support/RescriptEditorSupport.re
+++ b/src/rescript-editor-support/RescriptEditorSupport.re
@@ -5,7 +5,10 @@ let capabilities =
   J.o([
     ("textDocumentSync", J.i(1)),
     ("hoverProvider", J.t),
-    ("completionProvider", J.o([("triggerCharacters", J.l([J.s(".")]))])),
+    (
+      "completionProvider",
+      J.o([("triggerCharacters", J.l([J.s("."), J.s(">")]))]),
+    ),
     ("definitionProvider", J.t),
     ("typeDefinitionProvider", J.t),
     ("referencesProvider", J.t),


### PR DESCRIPTION
`x->` where `x` is a variable name of known type defined inside a module. E.g. `Belt.List.t`.