### PR TITLE
Add support for autocomplete for decorators such as `@module` and `@v…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ npm-debug.log
 *.install
 _build
 editor-extensions/vscode/*.zip
+examples/*/node_modules
+examples/*/lib
+editor-extensions/vscode/node_modules

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,10 @@
 ## master
+- Add support for autocomplete for `foo->`: the type of `foo` is used to determine the module to take completions from.
+- Add support for autocomplete for decorators such as `@module` and `@val`.
+
+## Release 1.0.5 of rescript-vscode
+This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/6bdd10f6af259edc5f9cbe5b9df06836de3ab865) is vendored in [rescript-vscode 1.0.5](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.5).
+
 - Add support for doc strings when hovering on modules.
 - Add support for printing uncurried function types in hover.
 - Fix autocomplete issue where `open Foo` would be picked up inside line comments (see https://github.com/rescript-lang/rescript-editor-support/issues/15).
@@ -6,7 +12,7 @@
 - Fix infinite loop in autocomplete that can cause `rescript-editor-support.exe` processes to use up 100% cpu.
 - Fix jump to type definition for types defined in an inner module.
 
-## Release 1.0.3 of rescript-vscode 
+## Release 1.0.3 of rescript-vscode
 This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/214d220d8573f9f0c8d54e623c163e01617bf124) is vendored in [rescript-vscode 1.0.3](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.3).
 
 - Fix type shown when hovering on record fields (see https://github.com/rescript-lang/rescript-vscode/issues/52), and doc comments for records.

--- a/src/rescript-editor-support/NewCompletions.re
+++ b/src/rescript-editor-support/NewCompletions.re
@@ -778,6 +778,48 @@ let computeCompletions = (~full, ~maybeText, ~package, ~pos, ~state) => {
       | None => []
       };
 
+    | Some((_, _, Some(Cdecorator(prefix)))) =>
+      let mkDecorator = name =>
+        mkItem(
+          ~name,
+          ~kind=4,
+          ~detail="",
+          ~docstring=None,
+          ~uri=full.file.uri,
+          ~pos_lnum=fst(pos),
+        );
+      [
+        "as",
+        "deriving",
+        "genType",
+        "genType.as",
+        "genType.import",
+        "genType.opaque",
+        "get",
+        "get_index",
+        "inline",
+        "int",
+        "meth",
+        "module",
+        "new",
+        "obj",
+        "react.component",
+        "return",
+        "scope",
+        "send",
+        "set",
+        "set_index",
+        "string",
+        "this",
+        "unboxed",
+        "uncurry",
+        "unwrap",
+        "val",
+        "variadic",
+      ]
+      |> List.filter(decorator => Utils.startsWith(decorator, prefix))
+      |> List.map(mkDecorator);
+
     | Some((_, _, Some(Clabel(_)))) =>
       // not supported yet
       []

--- a/src/rescript-editor-support/PartialParser.re
+++ b/src/rescript-editor-support/PartialParser.re
@@ -65,6 +65,7 @@ let rec startOfLident = (text, i) =>
   };
 
 type completable =
+  | Cdecorator(string)
   | Clabel(string)
   | Cpath(list(string))
   | Cpipe(string);
@@ -92,6 +93,7 @@ let findCompletable = (text, offset) => {
         switch (text.[i]) {
         | '>' when i > 0 && text.[i - 1] == '-' => loop(i - 2)
         | '~' => Some(Clabel(String.sub(text, i + 1, offset - (i + 1))))
+        | '@' => Some(Cdecorator(String.sub(text, i + 1, offset - (i + 1))))
         | 'a'..'z'
         | 'A'..'Z'
         | '0'..'9'

--- a/src/rescript-editor-support/RescriptEditorSupport.re
+++ b/src/rescript-editor-support/RescriptEditorSupport.re
@@ -7,7 +7,7 @@ let capabilities =
     ("hoverProvider", J.t),
     (
       "completionProvider",
-      J.o([("triggerCharacters", J.l([J.s("."), J.s(">")]))]),
+      J.o([("triggerCharacters", J.l([J.s("."), J.s(">"), J.s("@")]))]),
     ),
     ("definitionProvider", J.t),
     ("typeDefinitionProvider", J.t),
@@ -19,8 +19,7 @@ let capabilities =
   ]);
 
 let getInitialState = params => {
-  let rootUri =
-    Json.get("rootUri", params) |?> Json.string |?> Uri2.parse;
+  let rootUri = Json.get("rootUri", params) |?> Json.string |?> Uri2.parse;
   let%try rootUri = rootUri |> RResult.orError("Not a uri");
   let rootPath = Uri2.toPath(rootUri);
 


### PR DESCRIPTION
…al`.

Fixes https://github.com/rescript-lang/rescript-vscode/issues/26