### PR TITLE
Fix issue where values declared with type annotation would not show u…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,8 @@
 - Add support for autocomplete for decorators such as `@module` and `@val`.
 - Fix issue for uncurried functions where the internal definition of `Js.Fn.arity` is shown on hover. (See https://github.com/rescript-lang/rescript-editor-support/issues/62).
 - Fix type hint when hovering over labeled arguments of components (See https://github.com/rescript-lang/rescript-editor-support/issues/63).
+- Fix issue where values declared with type annotation would not show up in autocomplete, and would show no doc comment on hover. (See https://github.com/rescript-lang/rescript-vscode/issues/72).
+
 
 ## Release 1.0.5 of rescript-vscode
 This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/6bdd10f6af259edc5f9cbe5b9df06836de3ab865) is vendored in [rescript-vscode 1.0.5](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.5).

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -95,3 +95,6 @@ module Inner = {
 type typeInner = Inner.tInner;
 
 let valueInner = Inner.vInner;
+
+@ocaml.doc("Doc comment for functionWithTypeAnnotation")
+let functionWithTypeAnnotation : unit => int = () => 1

--- a/src/rescript-editor-support/ProcessCmt.re
+++ b/src/rescript-editor-support/ProcessCmt.re
@@ -407,7 +407,8 @@ let rec forItem = (~env, ~exported: exported, item) =>
       ({vb_loc, vb_pat: {pat_desc, pat_type}, vb_attributes}) =>
         /* TODO get all the things out of the var. */
         switch (pat_desc) {
-        | Tpat_var(ident, name) =>
+        | Tpat_var(ident, name)
+        | Tpat_alias({pat_desc: Tpat_any}, ident, name) /* let x : t = ... */ =>
           let item = pat_type;
           let declared =
             addItem(


### PR DESCRIPTION
…p in autocomplete, and would show no doc comment on hover.

Fixes https://github.com/rescript-lang/rescript-vscode/issues/72.

E.g.

```res
@ocaml.doc("Doc comment for functionWithTypeAnnotation")
let functionWithTypeAnnotation : unit => int = () => 1
```