### PR TITLE
Fix hover on definitions inside a react component module.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 - Fix issue for uncurried functions where the internal definition of `Js.Fn.arity` is shown on hover. (See https://github.com/rescript-lang/rescript-editor-support/issues/62).
 - Fix type hint when hovering over labeled arguments of components (See https://github.com/rescript-lang/rescript-editor-support/issues/63).
 - Fix issue where values declared with type annotation would not show up in autocomplete, and would show no doc comment on hover. (See https://github.com/rescript-lang/rescript-vscode/issues/72).
-
+- Fix hover on definitions inside a react component module, or whenever multiple definitins for the same value exist in the module (See https://github.com/rescript-lang/rescript-editor-support/issues/67).
 
 ## Release 1.0.5 of rescript-vscode
 This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/6bdd10f6af259edc5f9cbe5b9df06836de3ab865) is vendored in [rescript-vscode 1.0.5](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.5).

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -98,3 +98,10 @@ let valueInner = Inner.vInner;
 
 @ocaml.doc("Doc comment for functionWithTypeAnnotation")
 let functionWithTypeAnnotation : unit => int = () => 1
+
+module HoverInsideModuleWithComponent = {
+  let x = 2 // check that hover on x works
+
+  @react.component
+  let make = () => React.null
+}

--- a/src/rescript-editor-support/ProcessCmt.re
+++ b/src/rescript-editor-support/ProcessCmt.re
@@ -545,7 +545,12 @@ and forModule = (env, mod_desc, moduleName) =>
       modulePath: ExportedModule(moduleName, env.modulePath),
     };
     forModuleType(env, moduleType);
-  | Tmod_constraint(_expr, typ, _constraint, _coercion) =>
+  | Tmod_constraint(expr, _typ, Tmodtype_implicit, Tcoerce_structure(_)) =>
+    // implicit contraint synthesized during typechecking
+    // e.g. when the same id is defined twice (e.g. make with @react.component)
+    // skip the constraint and use the original module definition
+    forModule(env, expr.mod_desc, moduleName)
+  | Tmod_constraint(_expr, typ, constraint_, _coercion) =>
     /* TODO do this better I think */
     let env = {
       ...env,


### PR DESCRIPTION
This happens when a value is definied multiple times inside an inner module. E.g. @react.component defines `make` twice.

Fixes https://github.com/rescript-lang/rescript-editor-support/issues/67