### PR TITLE
Add support for autocomplete of labelled arguments.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 - Fix type hint when hovering over labeled arguments of components (See https://github.com/rescript-lang/rescript-editor-support/issues/63).
 - Fix issue where values declared with type annotation would not show up in autocomplete, and would show no doc comment on hover. (See https://github.com/rescript-lang/rescript-vscode/issues/72).
 - Fix hover on definitions inside a react component module, or whenever multiple definitins for the same value exist in the module (See https://github.com/rescript-lang/rescript-editor-support/issues/67).
+- Add support for autocomplete of labelled arguments `foo(~label... )`.
 
 ## Release 1.0.5 of rescript-vscode
 This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/6bdd10f6af259edc5f9cbe5b9df06836de3ab865) is vendored in [rescript-vscode 1.0.5](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.5).

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -105,3 +105,9 @@ module HoverInsideModuleWithComponent = {
   @react.component
   let make = () => React.null
 }
+
+module Lib = {
+  let foo = (~age, ~name) => name ++ string_of_int(age)
+  let next = (~number=0, ~year) => number + year
+}
+

--- a/src/rescript-editor-support/NotificationHandlers.re
+++ b/src/rescript-editor-support/NotificationHandlers.re
@@ -9,14 +9,6 @@ let getTextDocument = doc => {
   Some((uri, text));
 };
 
-let reloadAllState = state => {
-  Log.log("RELOADING ALL STATE");
-  {
-    ...TopTypes.empty(~rootUri=state.rootUri),
-    documentText: state.documentText,
-  };
-};
-
 let notificationHandlers:
   list((string, (state, Json.t) => result(state, string))) = [
   (

--- a/src/rescript-editor-support/RescriptEditorSupport.re
+++ b/src/rescript-editor-support/RescriptEditorSupport.re
@@ -7,7 +7,12 @@ let capabilities =
     ("hoverProvider", J.t),
     (
       "completionProvider",
-      J.o([("triggerCharacters", J.l([J.s("."), J.s(">"), J.s("@")]))]),
+      J.o([
+        (
+          "triggerCharacters",
+          J.l([J.s("."), J.s(">"), J.s("@"), J.s("~")]),
+        ),
+      ]),
     ),
     ("definitionProvider", J.t),
     ("typeDefinitionProvider", J.t),


### PR DESCRIPTION
Given a context `foo(... ~lab)`, parse backwards to find `foo`, get the type and list of labels, and complete from `lab`.

Fix https://github.com/rescript-lang/rescript-vscode/issues/65.