### PR TITLE
Add support for @deprecated attributes in autocomplete and hover.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,7 @@
 ## master
+- Add support for @deprecated attributes in autocomplete and hover.
+
+## Upcoming Release of rescript-vscode
 
 #### New features
 - Add support for autocomplete for pipe-first `foo->`: the type of `foo` is used to determine the module to take completions from.

--- a/editor-extensions/vscode/package-lock.json
+++ b/editor-extensions/vscode/package-lock.json
@@ -318,28 +318,45 @@
 			}
 		},
 		"vscode-jsonrpc": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.1.tgz",
-			"integrity": "sha512-+Eb+Dxf2kC2h079msx61hkblxAKE0S2j78+8QpnigLAO2aIIjkCwTIH34etBrU8E8VItRinec7YEwULx9at5bQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+			"integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==",
 			"dev": true
 		},
 		"vscode-languageclient": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.1.3.tgz",
-			"integrity": "sha512-3tu79B56apocobPGkHm7YWobjhNKCU7H4cUk+rkVFCNoOSAm2wZlN2J6HdC15/ONALY4ai25BeyQ+aQaFmM1Jg==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.4.tgz",
+			"integrity": "sha512-EUOU+bJu6axmt0RFNo3nrglQLPXMfanbYViJee3Fbn2VuQoX0ZOI4uTYhSRvYLP2vfwTP/juV62P/mksCdTZMA==",
 			"dev": true,
 			"requires": {
-				"vscode-languageserver-protocol": "^3.7.0"
+				"semver": "^6.3.0",
+				"vscode-languageserver-protocol": "3.15.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.7.1.tgz",
-			"integrity": "sha512-AKX9XQ49m/lpiDLZJBypFNc5eAXNlSecunYU5m4o5WIwGgW86TWnXVdziuFm47W2SdigDa/jVbxLPSNUeut9fQ==",
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+			"integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
 			"dev": true,
 			"requires": {
-				"vscode-jsonrpc": "^3.6.0",
-				"vscode-languageserver-types": "^3.7.0"
+				"vscode-jsonrpc": "^5.0.1",
+				"vscode-languageserver-types": "3.15.1"
+			},
+			"dependencies": {
+				"vscode-languageserver-types": {
+					"version": "3.15.1",
+					"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+					"integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==",
+					"dev": true
+				}
 			}
 		},
 		"vscode-languageserver-types": {

--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -10,7 +10,7 @@
 		"url": "https://github.com/jaredly/reason-language-server"
 	},
 	"engines": {
-		"vscode": "^1.22.0"
+		"vscode": "^1.43.0"
 	},
 	"categories": [
 		"Other"
@@ -143,7 +143,7 @@
 	},
 	"devDependencies": {
 		"vscode": "^1.1.17",
-		"vscode-languageclient": "^4.1.3",
+		"vscode-languageclient": "^6.1.3",
 		"vscode-languageserver-types": "^3.14.0",
 		"typescript": "^2.8.1"
 	}

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -111,3 +111,17 @@ module Lib = {
   let next = (~number=0, ~year) => number + year
 }
 
+@ocaml.doc("This module is commented")
+@deprecated("This module is deprecated")
+module Dep : {
+  @ocaml.doc("Some doc comment")
+  @deprecated("Use customDouble instead")
+  let customDouble : int => int
+
+  let customDouble2 : int => int
+} = {
+  let customDouble = foo => foo * 2
+  let customDouble2 = foo => foo * 2
+}
+
+let cc = Dep.customDouble(11)

--- a/src/rescript-editor-support/ProcessAttributes.re
+++ b/src/rescript-editor-support/ProcessAttributes.re
@@ -27,6 +27,32 @@ let rec findDocAttribute = attributes => {
   );
 };
 
+let rec findDeprecatedAttribute = attributes => {
+  Parsetree.(
+    switch (attributes) {
+    | [] => None
+    | [
+        (
+          {Asttypes.txt: "deprecated"},
+          PStr([
+            {
+              pstr_desc:
+                Pstr_eval(
+                  {pexp_desc: Pexp_constant(Pconst_string(msg, _))},
+                  _,
+                ),
+            },
+          ]),
+        ),
+        ..._,
+      ] =>
+      Some(msg)
+    | [({Asttypes.txt: "deprecated"}, _), ..._] => Some("")
+    | [_, ...rest] => findDeprecatedAttribute(rest)
+    }
+  );
+};
+
 let newDeclared =
     (
       ~item,
@@ -46,6 +72,7 @@ let newDeclared =
     scopeLoc: scope,
     exported,
     modulePath,
+    deprecated: findDeprecatedAttribute(attributes),
     docstring: findDocAttribute(attributes) |?>> processDoc,
     item,
     /* scopeType: Let, */

--- a/src/rescript-editor-support/ProcessCmt.re
+++ b/src/rescript-editor-support/ProcessCmt.re
@@ -550,7 +550,7 @@ and forModule = (env, mod_desc, moduleName) =>
     // e.g. when the same id is defined twice (e.g. make with @react.component)
     // skip the constraint and use the original module definition
     forModule(env, expr.mod_desc, moduleName)
-  | Tmod_constraint(_expr, typ, constraint_, _coercion) =>
+  | Tmod_constraint(_expr, typ, _constraint, _coercion) =>
     /* TODO do this better I think */
     let env = {
       ...env,

--- a/src/rescript-editor-support/References.re
+++ b/src/rescript-editor-support/References.re
@@ -99,10 +99,10 @@ let definedForLoc = (~file, ~getModule, locKind) => {
     switch (tip) {
     | Constructor(name) =>
       let%opt constructor = Query.getConstructor(file, stamp, name);
-      Some((None, file, `Constructor(constructor)));
+      Some((None, None, file, `Constructor(constructor)));
     | Field(name) =>
       let%opt field = Query.getField(file, stamp, name);
-      Some((None, file, `Field(field)));
+      Some((None, None, file, `Field(field)));
     | _ =>
       maybeLog(
         "Trying for declared "
@@ -114,7 +114,7 @@ let definedForLoc = (~file, ~getModule, locKind) => {
       );
       let%opt declared =
         Query.declaredForTip(~stamps=file.stamps, stamp, tip);
-      Some((declared.docstring, file, `Declared));
+      Some((declared.deprecated, declared.docstring, file, `Declared));
     };
   };
 

--- a/src/rescript-editor-support/SharedTypes.re
+++ b/src/rescript-editor-support/SharedTypes.re
@@ -53,6 +53,7 @@ type declared('t) = {
   stamp: int,
   modulePath: visibilityPath,
   exported: bool,
+  deprecated: option(string),
   docstring: option(string),
   item: 't,
   /* TODO maybe add a uri? */
@@ -67,6 +68,7 @@ let emptyDeclared = name => {
   stamp: 0,
   modulePath: NotVisible,
   exported: false,
+  deprecated: None,
   docstring: None,
   item: (),
 };


### PR DESCRIPTION
Add support for `@deprecated` attributes in autocomplete and hover.
For autocomplete: tell the client that the item is deprecated (typically shown with a strike-through by the client). Also, show the deprecation message.
For hover, show the deprecation message.

See https://github.com/rescript-lang/rescript-vscode/issues/45