### PR TITLE
Support for upcoming `rescript` npm package for the compiler.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,6 @@
 ## master
 - Add support for @deprecated attributes in autocomplete and hover.
+- Support for upcoming `rescript` npm package for the compiler. Look for `rescript` in addition to `bs-platform` in `node_modules`.
 
 ## Upcoming Release of rescript-vscode
 

--- a/src/rescript-editor-support/BuildSystem.re
+++ b/src/rescript-editor-support/BuildSystem.re
@@ -12,6 +12,15 @@ let getBsPlatformDir = rootPath => {
       ~startPath=rootPath,
       "bs-platform",
     );
+  let result =
+    if (result == None) {
+      ModuleResolution.resolveNodeModulePath(
+        ~startPath=rootPath,
+        "rescript",
+      );
+    } else {
+      result;
+    };
   switch (result) {
   | Some(path) => Ok(path)
   | None =>


### PR DESCRIPTION
Look for `rescript` in addition to `bs-platform` in `node_modules`.