### PR TITLE
Autocomplete: add support for `open!` in addition to `open`.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 ## master
 - Add support for @deprecated attributes in autocomplete and hover.
 - Support for upcoming `rescript` npm package for the compiler. Look for `rescript` in addition to `bs-platform` in `node_modules`.
+- Autocomplete: add support for `open!` in addition to `open`.
 
 ## Upcoming Release of rescript-vscode
 

--- a/src/rescript-editor-support/PartialParser.re
+++ b/src/rescript-editor-support/PartialParser.re
@@ -170,8 +170,16 @@ let findOpens = (text, offset) => {
         | '.'
         | '_'
         | '0'..'9' => loop(i - 1)
-        | ' ' =>
+        | ' '
+        | '!' =>
           let at = skipWhite(text, i - 1);
+          let at =
+            if (at >= 0 && text.[at] == '!') {
+              // handle open!
+              skipWhite(text, at - 1);
+            } else {
+              at;
+            };
           if (at >= 3
               && text.[at - 3] == 'o'
               && text.[at - 2] == 'p'


### PR DESCRIPTION
Normal case:
- `open! M`
Some corner cases:
- `open  !  M`
- `open!M`