### PR TITLE
WIP ground work for future autocomplete for JSX props.

### DIFF
--- a/src/rescript-editor-support/NewCompletions.re
+++ b/src/rescript-editor-support/NewCompletions.re
@@ -614,14 +614,26 @@ let processCompletable =
       ~package,
       ~state,
       ~pos,
-      ~text,
-      ~offset,
+      ~rawOpens,
+      ~allModules,
       completable: PartialParser.completable,
     ) =>
   switch (completable) {
+  | Cjsx(componentName, id) =>
+    ["first", "second"]
+    |> List.map(name =>
+         mkItem(
+           ~name=name ++ " " ++ componentName ++ " " ++ id,
+           ~kind=4,
+           ~deprecated=None,
+           ~detail="",
+           ~docstring=None,
+           ~uri=full.file.uri,
+           ~pos_lnum=fst(pos),
+         )
+       )
+
   | Cpath(parts) =>
-    let rawOpens = PartialParser.findOpens(text, offset);
-    let allModules = package.TopTypes.localModules @ package.dependencyModules;
     let items =
       getItems(
         ~full,
@@ -659,9 +671,6 @@ let processCompletable =
        );
 
   | Cpipe(s) =>
-    let rawOpens = PartialParser.findOpens(text, offset);
-    let allModules = package.TopTypes.localModules @ package.dependencyModules;
-
     let getItems = parts =>
       getItems(
         ~full,
@@ -830,9 +839,6 @@ let processCompletable =
     |> List.map(mkDecorator);
 
   | Clabel(funPath, prefix) =>
-    let rawOpens = PartialParser.findOpens(text, offset);
-    let allModules = package.TopTypes.localModules @ package.dependencyModules;
-
     let getItems = parts =>
       getItems(
         ~full,
@@ -890,8 +896,18 @@ let computeCompletions = (~full, ~maybeText, ~package, ~pos, ~state) => {
         switch (PartialParser.findCompletable(text, offset)) {
         | None => []
         | Some(completable) =>
+          let rawOpens = PartialParser.findOpens(text, offset);
+          let allModules =
+            package.TopTypes.localModules @ package.dependencyModules;
           completable
-          |> processCompletable(~full, ~package, ~state, ~pos, ~text, ~offset)
+          |> processCompletable(
+               ~full,
+               ~package,
+               ~state,
+               ~pos,
+               ~rawOpens,
+               ~allModules,
+             );
         }
       }
     };

--- a/src/rescript-editor-support/PartialParser.re
+++ b/src/rescript-editor-support/PartialParser.re
@@ -186,7 +186,7 @@ let findCompletable = (text, offset) => {
       let parts = Str.split(Str.regexp_string("."), s);
       let parts = s.[len - 1] == '.' ? parts @ [""] : parts;
       switch (parts) {
-      | [id] when String.lowercase_ascii(id) == id =>
+      | [id] when String.lowercase_ascii(id) == id && false /* TODO */ =>
         switch (findJsxContext(text, offset - len - 1)) {
         | None => Cpath(parts)
         | Some(componentName) => Cjsx(componentName, id)


### PR DESCRIPTION
Autocomplete for JSX props is only distinguished from autocomplete for identifiers by the context in which it takes place. Compared to completion of labeled arguments, it is not triggered by any special characters such as `~`.

The context is used as a heuristic to interpret the **intention**.

So for example, this should complete `foo` as a prop from `Comp`:

```rescript
<Comp foo
```

so should this

```rescript
<Comp x=3 foo
```

but this should complete as an identifier:

```rescript
<Comp x=foo
```

this should also complete as an identifier:

```rescript
<Comp List.m
```
as even though it's in a place where a prop name is expected, the intent is clearly to complete a value from module `List`.

This is a WIP to define what the contexts are.