### PR TITLE
Fix issue in jump-to-definition on Windows.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+# master
+- Fix issue in jump-to-definition on Windows. (See https://github.com/rescript-lang/rescript-vscode/issues/98) where the wrong URI was generated.
+
+
 ## Release 1.0.6 of rescript-vscode
 This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/03ee0d97b250474028d4fb08eac81ddb21ccb082) is vendored in [rescript-vscode 1.0.6](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.6).
 

--- a/src/rescript-editor-support/Uri2.re
+++ b/src/rescript-editor-support/Uri2.re
@@ -19,7 +19,7 @@ module Uri: {
       ++ (
         Str.global_replace(Str.regexp_string("\\"), "/", path)
         |> Str.substitute_first(
-             Str.regexp("^\\([A-Z]\\):"),
+             Str.regexp("^\\([a-zA-Z]\\):"),
              text => {
                let name = Str.matched_group(1, text);
                "/" ++ String.lowercase_ascii(name) ++ "%3A";


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/98#L345

The issue arises when the drive letter is lowercase.