### PR TITLE
Test stripping monadic ppx

### DIFF
--- a/src/rescript-editor-support/BuildSystem.re
+++ b/src/rescript-editor-support/BuildSystem.re
@@ -34,6 +34,7 @@ let getCompiledBase = root => {
   Files.ifExists(root /+ "lib" /+ "bs");
 };
 let getStdlib = base => {
-  let%try_wrap bsPlatformDir = getBsPlatformDir(base);
-  bsPlatformDir /+ "lib" /+ "ocaml";
+  Monads.Result.map(getBsPlatformDir(base), ~f=bsPlatformDir =>
+    bsPlatformDir /+ "lib" /+ "ocaml"
+  );
 };

--- a/src/rescript-editor-support/FindFiles.re
+++ b/src/rescript-editor-support/FindFiles.re
@@ -299,36 +299,40 @@ let findDependencyFiles = (~debug, base, config) => {
                  let namespace = getNamespace(inner);
                  let directories =
                    getSourceDirectories(~includeDev=false, loc, inner);
-                 let%opt compiledBase = BuildSystem.getCompiledBase(loc);
-                 /* |! "No compiled base found"; */
-                 if (debug) {
-                   Log.log("Compiled base: " ++ compiledBase);
-                 };
-                 let compiledDirectories =
-                   directories |> List.map(Files.fileConcat(compiledBase));
-                 let compiledDirectories =
-                   namespace == None
-                     ? compiledDirectories
-                     : [compiledBase, ...compiledDirectories];
-                 let files =
-                   findProjectFiles(
-                     ~debug,
-                     namespace,
-                     loc,
-                     directories,
-                     compiledBase,
-                   );
-                 /* let files =
-                    switch (namespace) {
-                    | None =>
-                       files
-                    | Some(namespace) =>
-                      files
-                      |> List.map(((name, paths)) =>
-                           (namespace ++ "-" ++ name, paths)
-                         )
-                    }; */
-                 Some((compiledDirectories, files));
+                 Monads.Option.bind(
+                   BuildSystem.getCompiledBase(loc),
+                   ~f=compiledBase => {
+                    /* |! "No compiled base found"; */
+                    if (debug) {
+                      Log.log("Compiled base: " ++ compiledBase);
+                    };
+                    let compiledDirectories =
+                      directories |> List.map(Files.fileConcat(compiledBase));
+                    let compiledDirectories =
+                      namespace == None
+                        ? compiledDirectories
+                        : [compiledBase, ...compiledDirectories];
+                    let files =
+                      findProjectFiles(
+                        ~debug,
+                        namespace,
+                        loc,
+                        directories,
+                        compiledBase,
+                      );
+                    /* let files =
+                      switch (namespace) {
+                      | None =>
+                         files
+                      | Some(namespace) =>
+                        files
+                        |> List.map(((name, paths)) =>
+                             (namespace ++ "-" ++ name, paths)
+                           )
+                      }; */
+                    Some((compiledDirectories, files));
+                  },
+                );
                | None => None
                };
              }
@@ -343,8 +347,12 @@ let findDependencyFiles = (~debug, base, config) => {
        });
   let (directories, files) = List.split(depFiles);
   let files = List.concat(files);
-  let%try stdlibDirectory = BuildSystem.getStdlib(base);
-  let directories = [stdlibDirectory, ...List.concat(directories)];
-  let results = files @ collectFiles(stdlibDirectory);
-  Ok((directories, results));
+  Monads.Result.bind(
+    BuildSystem.getStdlib(base),
+    ~f=stdlibDirectory => {
+      let directories = [stdlibDirectory, ...List.concat(directories)];
+      let results = files @ collectFiles(stdlibDirectory);
+      Ok((directories, results));
+    },
+  );
 };


### PR DESCRIPTION
I've built ppx_monad as a standalone binary, ran it through the file, printed it back to reason, and hand-adjusted the rest (since whitespace and braces are lost during this pass). This code should be correct without needing to test.
