### PR TITLE
Make the unmonad script turn the let% into `switch` instead

### DIFF
--- a/src/rescript-editor-support/BuildSystem.re
+++ b/src/rescript-editor-support/BuildSystem.re
@@ -30,7 +30,8 @@ let getBsPlatformDir = rootPath => {
 let getCompiledBase = root => {
   Files.ifExists(root /+ "lib" /+ "bs");
 };
-let getStdlib = base => {
-  let%try_wrap bsPlatformDir = getBsPlatformDir(base);
-  bsPlatformDir /+ "lib" /+ "ocaml";
-};
+let getStdlib = base =>
+  switch (getBsPlatformDir(base)) {
+  | Error(e) => Error(e)
+  | Ok(bsPlatformDir) => Ok(bsPlatformDir /+ "lib" /+ "ocaml")
+  };


### PR DESCRIPTION
Follow-up of #87

Now we can properly add error handling to these `None`/`Error(_)` later

