### PR TITLE
Convert everything over to unmonad

### DIFF
--- a/src/rescript-editor-support/Hover.re
+++ b/src/rescript-editor-support/Hover.re
@@ -2,12 +2,19 @@ let digConstructor = (~env, ~getModule, path) => {
   switch (Query.resolveFromCompilerPath(~env, ~getModule, path)) {
   | `Not_found => None
   | `Stamp(stamp) =>
-    let%opt t = Hashtbl.find_opt(env.file.stamps.types, stamp);
-    Some((env, t));
+    switch (Hashtbl.find_opt(env.file.stamps.types, stamp)) {
+    | None => None
+    | Some(t) => Some((env, t))
+    }
   | `Exported(env, name) =>
-    let%opt stamp = Hashtbl.find_opt(env.exported.types, name);
-    let%opt t = Hashtbl.find_opt(env.file.stamps.types, stamp);
-    Some((env, t));
+    switch (Hashtbl.find_opt(env.exported.types, name)) {
+    | None => None
+    | Some(stamp) =>
+      switch (Hashtbl.find_opt(env.file.stamps.types, stamp)) {
+      | None => None
+      | Some(t) => Some((env, t))
+      }
+    }
   | _ => None
   };
 };
@@ -67,38 +74,60 @@ let newHover = (~file: SharedTypes.file, ~getModule, loc) => {
     Some(codeBlock(typeDef));
   | LModule(Definition(stamp, _tip))
   | LModule(LocalReference(stamp, _tip)) =>
-    let%opt md = Hashtbl.find_opt(file.stamps.modules, stamp);
-    let%opt (file, declared) =
-      References.resolveModuleReference(~file, ~getModule, md);
-    let (name, docstring) =
-      switch (declared) {
-      | Some(d) => (d.name.txt, d.docstring)
-      | None => (file.moduleName, file.contents.docstring)
-      };
-    showModule(~docstring, ~name, ~file, declared);
+    switch (Hashtbl.find_opt(file.stamps.modules, stamp)) {
+    | None => None
+    | Some(md) =>
+      switch (References.resolveModuleReference(~file, ~getModule, md)) {
+      | None => None
+      | Some((file, declared)) =>
+        let (name, docstring) =
+          switch (declared) {
+          | Some(d) => (d.name.txt, d.docstring)
+          | None => (file.moduleName, file.contents.docstring)
+          };
+        showModule(~docstring, ~name, ~file, declared);
+      }
+    }
   | LModule(GlobalReference(moduleName, path, tip)) =>
-    let%opt file = getModule(moduleName);
-    let env = Query.fileEnv(file);
-    let%opt (env, name) = Query.resolvePath(~env, ~path, ~getModule);
-    let%opt stamp = Query.exportedForTip(~env, name, tip);
-    let%opt md = Hashtbl.find_opt(file.stamps.modules, stamp);
-    let%opt (file, declared) =
-      References.resolveModuleReference(~file, ~getModule, md);
-    let (name, docstring) =
-      switch (declared) {
-      | Some(d) => (d.name.txt, d.docstring)
-      | None => (file.moduleName, file.contents.docstring)
+    switch (getModule(moduleName)) {
+    | None => None
+    | Some(file) =>
+      let env = Query.fileEnv(file);
+      switch (Query.resolvePath(~env, ~path, ~getModule)) {
+      | None => None
+      | Some((env, name)) =>
+        switch (Query.exportedForTip(~env, name, tip)) {
+        | None => None
+        | Some(stamp) =>
+          switch (Hashtbl.find_opt(file.stamps.modules, stamp)) {
+          | None => None
+          | Some(md) =>
+            switch (References.resolveModuleReference(~file, ~getModule, md)) {
+            | None => None
+            | Some((file, declared)) =>
+              let (name, docstring) =
+                switch (declared) {
+                | Some(d) => (d.name.txt, d.docstring)
+                | None => (file.moduleName, file.contents.docstring)
+                };
+              showModule(~docstring, ~name, ~file, declared);
+            }
+          }
+        }
       };
-    showModule(~docstring, ~name, ~file, declared);
+    }
   | LModule(NotFound) => None
   | TopLevelModule(name) =>
-    let%opt file = getModule(name);
-    showModule(
-      ~docstring=file.contents.docstring,
-      ~name=file.moduleName,
-      ~file,
-      None,
-    );
+    switch (getModule(name)) {
+    | None => None
+    | Some(file) =>
+      showModule(
+        ~docstring=file.contents.docstring,
+        ~name=file.moduleName,
+        ~file,
+        None,
+      )
+    }
   | Typed(_, Definition(_, Field(_) | Constructor(_))) => None
   | Constant(t) =>
     Some(
@@ -117,15 +146,20 @@ let newHover = (~file: SharedTypes.file, ~getModule, loc) => {
       let typeString = codeBlock(typ |> Shared.typeToString);
       let extraTypeInfo = {
         let env = Query.fileEnv(file);
-        let%opt path = typ |> Shared.digConstructor;
-        let%opt (_env, {docstring, name: {txt}, item: {decl}}) =
-          digConstructor(~env, ~getModule, path);
-        let isUncurriedInternal =
-          Utils.startsWith(Path.name(path), "Js.Fn.arity");
-        if (isUncurriedInternal) {
-          None;
-        } else {
-          Some((decl |> Shared.declToString(txt), docstring));
+        switch (typ |> Shared.digConstructor) {
+        | None => None
+        | Some(path) =>
+          switch (digConstructor(~env, ~getModule, path)) {
+          | None => None
+          | Some((_env, {docstring, name: {txt}, item: {decl}})) =>
+            let isUncurriedInternal =
+              Utils.startsWith(Path.name(path), "Js.Fn.arity");
+            if (isUncurriedInternal) {
+              None;
+            } else {
+              Some((decl |> Shared.declToString(txt), docstring));
+            };
+          }
         };
       };
       let (typeString, docstring) =

--- a/src/rescript-editor-support/MessageHandlers.re
+++ b/src/rescript-editor-support/MessageHandlers.re
@@ -8,348 +8,427 @@ let handlers:
   (
     "textDocument/definition",
     (state, params) => {
-      let%try (uri, pos) = Protocol.rPositionParams(params);
-      let%try (package, {file, extra}) = State.getFullFromCmt(~state, ~uri);
-
-      let position = Utils.cmtLocFromVscode(pos);
-
-      {
-        let%opt (uri, loc) =
-          References.definitionForPos(
-            ~pathsForModule=package.pathsForModule,
-            ~file,
-            ~extra,
-            ~getUri=State.fileForUri(state),
-            ~getModule=State.fileForModule(state, ~package),
-            position,
-          );
-        Some(
-          Ok((
-            state,
-            Json.Object([
-              ("uri", Json.String(Uri2.toString(uri))),
-              ("range", Protocol.rangeOfLoc(loc)),
-            ]),
-          )),
-        );
+      switch (Protocol.rPositionParams(params)) {
+      | Error(e) => Error(e)
+      | Ok((uri, pos)) =>
+        switch (State.getFullFromCmt(~state, ~uri)) {
+        | Error(e) => Error(e)
+        | Ok((package, {file, extra})) =>
+          let position = Utils.cmtLocFromVscode(pos);
+          (
+            switch (
+              References.definitionForPos(
+                ~pathsForModule=package.pathsForModule,
+                ~file,
+                ~extra,
+                ~getUri=State.fileForUri(state),
+                ~getModule=State.fileForModule(state, ~package),
+                position,
+              )
+            ) {
+            | None => None
+            | Some((uri, loc)) =>
+              Some(
+                Ok((
+                  state,
+                  Json.Object([
+                    ("uri", Json.String(Uri2.toString(uri))),
+                    ("range", Protocol.rangeOfLoc(loc)),
+                  ]),
+                )),
+              );
+            }
+          )
+          |? Ok((state, Json.Null));
+        }
       }
-      |? Ok((state, Json.Null));
-    },
+    }
   ),
   (
     "textDocument/completion",
     (state, params) => {
-      let%try (uri, pos) = Protocol.rPositionParams(params);
-      let maybeText =
-        switch (Hashtbl.find_opt(state.documentText, uri)) {
-        | Some(text) => Some(text)
-        | None => None
+      switch (Protocol.rPositionParams(params)) {
+      | Error(e) => Error(e)
+      | Ok((uri, pos)) =>
+        let maybeText =
+          switch (Hashtbl.find_opt(state.documentText, uri)) {
+          | Some(text) => Some(text)
+          | None => None
+          };
+        switch (State.getFullFromCmt(~state, ~uri)) {
+        | Error(e) => Error(e)
+        | Ok((package, full)) =>
+          let completions =
+            NewCompletions.computeCompletions(
+              ~full,
+              ~maybeText,
+              ~package,
+              ~pos,
+              ~state,
+            );
+          Ok((state, completions));
         };
-      let%try (package, full) = State.getFullFromCmt(~state, ~uri);
-      let completions =
-        NewCompletions.computeCompletions(
-          ~full,
-          ~maybeText,
-          ~package,
-          ~pos,
-          ~state,
-        );
-      Ok((state, completions));
-    },
+      }
+    }
   ),
   (
     "textDocument/documentHighlight",
     (state, params) => {
-      let%try (uri, pos) = Protocol.rPositionParams(params);
-
-      let pos = Utils.cmtLocFromVscode(pos);
-      let refs =
-        switch (State.fileForUri(state, uri) |> toOptionAndLog) {
-        | None => None
-        | Some((file, extra)) => References.refsForPos(~file, ~extra, pos)
-        };
-      Ok((
-        state,
-        switch (refs) {
-        | None => J.null
-        | Some(refs) =>
-          J.l(
-            refs
-            |> List.map(loc =>
-                 J.o([
-                   ("range", Protocol.rangeOfLoc(loc)),
-                   ("kind", J.i(2)),
-                 ])
-               ),
-          )
-        },
-      ));
-    },
+      switch (Protocol.rPositionParams(params)) {
+      | Error(e) => Error(e)
+      | Ok((uri, pos)) =>
+        let pos = Utils.cmtLocFromVscode(pos);
+        let refs =
+          switch (State.fileForUri(state, uri) |> toOptionAndLog) {
+          | None => None
+          | Some((file, extra)) => References.refsForPos(~file, ~extra, pos)
+          };
+        Ok((
+          state,
+          switch (refs) {
+          | None => J.null
+          | Some(refs) =>
+            J.l(
+              refs
+              |> List.map(loc =>
+                   J.o([
+                     ("range", Protocol.rangeOfLoc(loc)),
+                     ("kind", J.i(2)),
+                   ])
+                 ),
+            )
+          },
+        ));
+      }
+    }
   ),
   (
     "textDocument/references",
     (state, params) => {
-      let%try (uri, pos) = Protocol.rPositionParams(params);
-      let%try package = Packages.getPackage(uri, state);
-      let%try_wrap (file, extra) = State.fileForUri(state, uri);
-      Infix.(
-        {
-          let%opt (_, loc) =
-            References.locForPos(~extra, Utils.cmtLocFromVscode(pos));
-          let%opt allReferences =
-            References.allReferencesForLoc(
-              ~pathsForModule=package.pathsForModule,
-              ~file,
-              ~extra,
-              ~allModules=package.localModules,
-              ~getUri=State.fileForUri(state),
-              ~getModule=State.fileForModule(state, ~package),
-              ~getExtra=State.extraForModule(state, ~package),
-              loc,
+      switch (Protocol.rPositionParams(params)) {
+      | Error(e) => Error(e)
+      | Ok((uri, pos)) =>
+        switch (Packages.getPackage(uri, state)) {
+        | Error(e) => Error(e)
+        | Ok(package) =>
+          switch (State.fileForUri(state, uri)) {
+          | Error(e) => Error(e)
+          | Ok((file, extra)) =>
+            Ok(
+              Infix.(
+                (
+                  switch (
+                    References.locForPos(~extra, Utils.cmtLocFromVscode(pos))
+                  ) {
+                  | None => None
+                  | Some((_, loc)) =>
+                    switch (
+                      References.allReferencesForLoc(
+                        ~pathsForModule=package.pathsForModule,
+                        ~file,
+                        ~extra,
+                        ~allModules=package.localModules,
+                        ~getUri=State.fileForUri(state),
+                        ~getModule=State.fileForModule(state, ~package),
+                        ~getExtra=State.extraForModule(state, ~package),
+                        loc,
+                      )
+                      |> toOptionAndLog
+                    ) {
+                    | None => None
+                    | Some(allReferences) =>
+                      Some((
+                        state,
+                        J.l(
+                          allReferences
+                          |> List.map(((fname, references)) => {
+                               let locs =
+                                 fname == uri
+                                   ? List.filter(
+                                       loc => !Protocol.locationContains(loc, pos),
+                                       references,
+                                     )
+                                   : references;
+                               locs
+                               |> List.map(loc => Protocol.locationOfLoc(~fname, loc));
+                             })
+                          |> List.concat,
+                        ),
+                      ));
+                    }
+                  }
+                )
+                |? (state, J.null)
+              ),
             )
-            |> toOptionAndLog;
-          Some((
-            state,
-            J.l(
-              allReferences
-              |> List.map(((fname, references)) => {
-                   let locs =
-                     fname == uri
-                       ? List.filter(
-                           loc => !Protocol.locationContains(loc, pos),
-                           references,
-                         )
-                       : references;
-                   locs
-                   |> List.map(loc => Protocol.locationOfLoc(~fname, loc));
-                 })
-              |> List.concat,
-            ),
-          ));
+          }
         }
-        |? (state, J.null)
-      );
-    },
+      }
+    }
   ),
   (
     "textDocument/rename",
     (state, params) => {
-      let%try (uri, pos) = Protocol.rPositionParams(params);
-      let%try package = Packages.getPackage(uri, state);
-      let%try (file, extra) = State.fileForUri(state, uri);
-      let%try newName = RJson.get("newName", params);
-      Infix.(
-        {
-          let%opt (_, loc) =
-            References.locForPos(~extra, Utils.cmtLocFromVscode(pos));
-          let%opt allReferences =
-            References.allReferencesForLoc(
-              ~file,
-              ~extra,
-              ~pathsForModule=package.pathsForModule,
-              ~allModules=package.localModules,
-              ~getModule=State.fileForModule(state, ~package),
-              ~getUri=State.fileForUri(state),
-              ~getExtra=State.extraForModule(state, ~package),
-              loc,
-            )
-            |> toOptionAndLog;
-          Some(
-            Ok((
-              state,
-              J.o([
-                (
-                  "changes",
-                  J.o(
-                    allReferences
-                    |> List.map(((fname, references)) =>
-                         (
-                           fname |> Uri2.toString,
-                           J.l(
-                             references
-                             |> List.map(loc =>
-                                  J.o([
-                                    ("range", Protocol.rangeOfLoc(loc)),
-                                    ("newText", newName),
-                                  ])
-                                ),
-                           ),
-                         )
-                       ),
-                  ),
-                ),
-              ]),
-            )),
-          );
+      switch (Protocol.rPositionParams(params)) {
+      | Error(e) => Error(e)
+      | Ok((uri, pos)) =>
+        switch (Packages.getPackage(uri, state)) {
+        | Error(e) => Error(e)
+        | Ok(package) =>
+          switch (State.fileForUri(state, uri)) {
+          | Error(e) => Error(e)
+          | Ok((file, extra)) =>
+            switch (RJson.get("newName", params)) {
+            | Error(e) => Error(e)
+            | Ok(newName) =>
+              open Infix;
+              (
+                switch (
+                  References.locForPos(~extra, Utils.cmtLocFromVscode(pos))
+                ) {
+                | None => None
+                | Some((_, loc)) =>
+                  switch (
+                    References.allReferencesForLoc(
+                      ~file,
+                      ~extra,
+                      ~pathsForModule=package.pathsForModule,
+                      ~allModules=package.localModules,
+                      ~getModule=State.fileForModule(state, ~package),
+                      ~getUri=State.fileForUri(state),
+                      ~getExtra=State.extraForModule(state, ~package),
+                      loc,
+                    )
+                    |> toOptionAndLog
+                  ) {
+                  | None => None
+                  | Some(allReferences) =>
+                    Some(
+                      Ok((
+                        state,
+                        J.o([
+                          (
+                            "changes",
+                            J.o(
+                              allReferences
+                              |> List.map(((fname, references)) =>
+                                    (
+                                      fname |> Uri2.toString,
+                                      J.l(
+                                        references
+                                        |> List.map(loc =>
+                                            J.o([
+                                              ( "range", Protocol.rangeOfLoc(loc)),
+                                              ("newText", newName),
+                                            ])
+                                          ),
+                                      ),
+                                    )
+                                  ),
+                            ),
+                          ),
+                        ]),
+                      ),
+                    ))
+                  }
+                }
+              )
+              |? Ok((state, J.null))
+            }
+          }
         }
-        |? Ok((state, J.null))
-      );
-    },
+      }
+    }
   ),
   (
     "textDocument/codeLens",
     (state, params) => {
       open InfixResult;
-      let%try uri =
+      switch (
         params
         |> RJson.get("textDocument")
         |?> RJson.get("uri")
-        |?> RJson.string;
-      let%try uri = Uri2.parse(uri) |> RResult.orError("Not a uri");
-
-      /* Log.log("<< codleens me please"); */
-
-      let topLoc = {
-        Location.loc_start: {
-          Lexing.pos_fname: "",
-          pos_lnum: 1,
-          pos_bol: 0,
-          pos_cnum: 0,
-        },
-        Location.loc_end: {
-          Lexing.pos_fname: "",
-          pos_lnum: 1,
-          pos_bol: 0,
-          pos_cnum: 0,
-        },
-        loc_ghost: false,
-      };
-
-      let getLensItems = ({SharedTypes.file, extra}) => {
-        /* getTypeLensTopLevel gives the list of per-value type codeLens
-           for every value in a module topLevel */
-        let rec getTypeLensTopLevel = topLevel => {
-          switch (topLevel) {
-          | [] => []
-          | [{SharedTypes.name: {loc}, item}, ...tlp] =>
-            let currentCl =
-              switch (item) {
-              | SharedTypes.MValue(typ) => [
-                  (typ |> Shared.typeToString, loc),
-                ]
-              | Module(Structure({topLevel})) =>
-                getTypeLensTopLevel(topLevel)
-              | _ => []
-              };
-            List.append(currentCl, getTypeLensTopLevel(tlp));
+        |?> RJson.string
+      ) {
+      | Error(e) => Error(e)
+      | Ok(uri) =>
+        switch (Uri2.parse(uri) |> RResult.orError("Not a uri")) {
+        | Error(e) => Error(e)
+        | Ok(uri) =>
+          /* Log.log("<< codleens me please"); */
+          let topLoc = {
+            Location.loc_start: {
+              Lexing.pos_fname: "",
+              pos_lnum: 1,
+              pos_bol: 0,
+              pos_cnum: 0,
+            },
+            Location.loc_end: {
+              Lexing.pos_fname: "",
+              pos_lnum: 1,
+              pos_bol: 0,
+              pos_cnum: 0,
+            },
+            loc_ghost: false,
           };
-        };
-        let lenses = file.contents.topLevel |> getTypeLensTopLevel;
-        let lenses = lenses @ CodeLens.forOpens(extra);
+          let getLensItems = ({SharedTypes.file, extra}) => {
+            /* getTypeLensTopLevel gives the list of per-value type codeLens
+              for every value in a module topLevel */
+            let rec getTypeLensTopLevel = topLevel => {
+              switch (topLevel) {
+              | [] => []
+              | [{SharedTypes.name: {loc}, item}, ...tlp] =>
+                let currentCl =
+                  switch (item) {
+                  | SharedTypes.MValue(typ) => [
+                      (typ |> Shared.typeToString, loc),
+                    ]
+                  | Module(Structure({topLevel})) =>
+                    getTypeLensTopLevel(topLevel)
+                  | _ => []
+                  };
+                List.append(currentCl, getTypeLensTopLevel(tlp));
+              };
+            };
+            let lenses = file.contents.topLevel |> getTypeLensTopLevel;
+            let lenses = lenses @ CodeLens.forOpens(extra);
+            let depsList =
+              List.map(fst, SharedTypes.hashList(extra.externalReferences));
+            let depsString =
+              depsList == [] ? "[none]" : String.concat(", ", depsList);
+            let lenses = [("Dependencies: " ++ depsString, topLoc), ...lenses];
+            lenses;
+          };
+          let items =
+            switch (State.getFullFromCmt(~state, ~uri)) {
+            | Error(message) => [(message, topLoc)]
+            | Ok((_package, full)) => getLensItems(full)
+            };
+          Ok((
+            state,
+            J.l(
+              items
+              |> List.map(((text, loc)) =>
+                    J.o([
+                      ("range", Protocol.rangeOfLoc(loc)),
+                      (
+                        "command",
+                        J.o([("title", J.s(text)), ("command", J.s(""))]),
+                      ),
+                    ])
+                  ),
+            ),
+          ));
+        }
+      }
 
-        let depsList =
-          List.map(fst, SharedTypes.hashList(extra.externalReferences));
-        let depsString =
-          depsList == [] ? "[none]" : String.concat(", ", depsList);
-        let lenses = [("Dependencies: " ++ depsString, topLoc), ...lenses];
-
-        lenses;
-      };
-
-      let items = {
-        switch (State.getFullFromCmt(~state, ~uri)) {
-        | Error(message) => [(message, topLoc)]
-        | Ok((_package, full)) => getLensItems(full)
-        };
-      };
-      Ok((
-        state,
-        J.l(
-          items
-          |> List.map(((text, loc)) =>
-               J.o([
-                 ("range", Protocol.rangeOfLoc(loc)),
-                 (
-                   "command",
-                   J.o([("title", J.s(text)), ("command", J.s(""))]),
-                 ),
-               ])
-             ),
-        ),
-      ));
-    },
+    }
   ),
   (
     "textDocument/hover",
     (state, params) => {
-      let%try (uri, pos) = Protocol.rPositionParams(params);
-      let%try package = Packages.getPackage(uri, state);
-      let%try (file, extra) = State.fileForUri(state, uri);
-
-      {
-        let pos = Utils.cmtLocFromVscode(pos);
-        let%opt (location, loc) = References.locForPos(~extra, pos);
-        let%opt text =
-          Hover.newHover(
-            ~file,
-            ~getModule=State.fileForModule(state, ~package),
-            loc,
-          );
-        Some(
-          Ok((
-            state,
-            J.o([
-              ("range", Protocol.rangeOfLoc(location)),
-              ("contents", text |> Protocol.contentKind),
-            ]),
-          )),
-        );
+      switch (Protocol.rPositionParams(params)) {
+      | Error(e) => Error(e)
+      | Ok((uri, pos)) =>
+        switch (Packages.getPackage(uri, state)) {
+        | Error(e) => Error(e)
+        | Ok(package) =>
+          switch (State.fileForUri(state, uri)) {
+          | Error(e) => Error(e)
+          | Ok((file, extra)) =>
+            {
+              let pos = Utils.cmtLocFromVscode(pos);
+              switch (References.locForPos(~extra, pos)) {
+              | None => None
+              | Some((location, loc)) =>
+                switch (
+                  Hover.newHover(
+                    ~file,
+                    ~getModule=State.fileForModule(state, ~package),
+                    loc,
+                  )
+                ) {
+                | None => None
+                | Some(text) =>
+                  Some(
+                    Ok((
+                      state,
+                      J.o([
+                        ("range", Protocol.rangeOfLoc(location)),
+                        ("contents", text |> Protocol.contentKind),
+                      ]),
+                    ),
+                  ))
+                }
+              };
+            }
+            |? Ok((state, J.null))
+          }
+        }
       }
-      |? Ok((state, J.null));
-    },
+    }
   ),
   (
     "textDocument/documentSymbol",
     (state, params) => {
       open InfixResult;
-      let%try uri =
+      switch (
         params
         |> RJson.get("textDocument")
         |?> RJson.get("uri")
-        |?> RJson.string;
-      let%try uri = Uri2.parse(uri) |> RResult.orError("Not a uri");
+        |?> RJson.string
+      ) {
+      | Error(e) => Error(e)
+      | Ok(uri) =>
+        switch (Uri2.parse(uri) |> RResult.orError("Not a uri")) {
+        | Error(e) => Error(e)
+        | Ok(uri) =>
+          switch (State.fileForUri(state, uri)) {
+          | Error(e) => Error(e)
+          | Ok((file, _extra)) =>
+            open SharedTypes;
 
-      let%try (file, _extra) = State.fileForUri(state, uri);
-      open SharedTypes;
-
-      let rec getItems = ({topLevel}) => {
-        let fn = ({name: {txt}, extentLoc, item}) => {
-          let (item, siblings) =
-            switch (item) {
-            | MValue(v) => (v |> Shared.variableKind, [])
-            | MType(t, _) => (t.decl |> Shared.declarationKind, [])
-            | Module(Structure(contents)) => (Module, getItems(contents))
-            | Module(Ident(_)) => (Module, [])
+            let rec getItems = ({topLevel}) => {
+              let fn = ({name: {txt}, extentLoc, item}) => {
+                let (item, siblings) =
+                  switch (item) {
+                  | MValue(v) => (v |> Shared.variableKind, [])
+                  | MType(t, _) => (t.decl |> Shared.declarationKind, [])
+                  | Module(Structure(contents)) => (Module, getItems(contents))
+                  | Module(Ident(_)) => (Module, [])
+                  };
+                if (extentLoc.loc_ghost) {
+                  siblings;
+                } else {
+                  [(txt, extentLoc, item), ...siblings];
+                };
+              };
+              let x = topLevel |> List.map(fn) |> List.concat;
+              x;
             };
-          if (extentLoc.loc_ghost) {
-            siblings;
-          } else {
-            [(txt, extentLoc, item), ...siblings];
-          };
-        };
-        let x = topLevel |> List.map(fn) |> List.concat;
-        x;
-      };
 
-      getItems(file.contents)
-      |> (
-        items => {
-          Ok((
-            state,
-            J.l(
-              items
-              |> List.map(((name, loc, typ)) =>
-                   J.o([
-                     ("name", J.s(name)),
-                     ("kind", J.i(Protocol.symbolKind(typ))),
-                     ("location", Protocol.locationOfLoc(loc)),
-                     /* ("containerName", s(String.concat(".", path))) */
-                   ])
-                 ),
-            ),
-          ));
+            getItems(file.contents)
+            |> (
+              items => {
+                Ok((
+                  state,
+                  J.l(
+                    items
+                    |> List.map(((name, loc, typ)) =>
+                          J.o([
+                            ("name", J.s(name)),
+                            ("kind", J.i(Protocol.symbolKind(typ))),
+                            ("location", Protocol.locationOfLoc(loc)),
+                            /* ("containerName", s(String.concat(".", path))) */
+                          ])
+                        ),
+                  ),
+                ));
+              }
+            );
+          }
         }
-      );
-    },
+      }
+    }
   ),
 ];

--- a/src/rescript-editor-support/NotificationHandlers.re
+++ b/src/rescript-editor-support/NotificationHandlers.re
@@ -3,48 +3,58 @@ open RResult;
 open TopTypes;
 module J = JsonShort;
 
-let getTextDocument = doc => {
-  let%opt uri = Json.get("uri", doc) |?> Json.string |?> Uri2.parse;
-  let%opt text = Json.get("text", doc) |?> Json.string;
-  Some((uri, text));
-};
+let getTextDocument = doc =>
+  switch (Json.get("uri", doc) |?> Json.string |?> Uri2.parse) {
+  | None => None
+  | Some(uri) =>
+    switch (Json.get("text", doc) |?> Json.string) {
+    | None => None
+    | Some(text) => Some((uri, text))
+    }
+  };
 
 let notificationHandlers:
   list((string, (state, Json.t) => result(state, string))) = [
   (
     "textDocument/didOpen",
     (state, params) => {
-      let%try (uri, text) =
+      switch (
         Json.get("textDocument", params)
         |?> getTextDocument
-        |> RResult.orError("Invalid params");
-      Hashtbl.replace(state.documentText, uri, text);
-
-      let path = Uri2.toPath(uri);
-      if (FindFiles.isSourceFile(path)) {
-        let%try package = Packages.getPackage(uri, state);
-        /* let name = FindFiles.getName(path); */
-        if (!Hashtbl.mem(package.nameForPath, path)) {
-          /* TODO: figure out what the name should be, and process it. */
-          package.nameForPath
-          |> Hashtbl.iter((name, _) => Log.log(" > " ++ name));
-          Log.log("Reloading because you created a new file: " ++ path);
-          Ok(state);
-          /* Ok(reloadAllState(state)) */
-          /* Hashtbl.add(package.nameForPath, path, name);
-             Hashtbl.add(package.pathsForModule, name, Impl(path, Some(path)));
-             Hashtbl.replace(state.packagesByRoot, package.basePath, {
-               ...package,
-               localModules: [name, ...package.localModules]
-             });
-             Ok(state) */
+        |> RResult.orError("Invalid params")
+      ) {
+      | Error(e) => Error(e)
+      | Ok((uri, text)) =>
+        Hashtbl.replace(state.documentText, uri, text);
+        let path = Uri2.toPath(uri);
+        if (FindFiles.isSourceFile(path)) {
+          switch (Packages.getPackage(uri, state)) {
+          | Error(e) => Error(e)
+          | Ok(package) =>
+            /* let name = FindFiles.getName(path); */
+            if (!Hashtbl.mem(package.nameForPath, path)) {
+              /* TODO: figure out what the name should be, and process it. */
+              package.nameForPath
+              |> Hashtbl.iter((name, _) => Log.log(" > " ++ name));
+              Log.log("Reloading because you created a new file: " ++ path);
+              Ok(state);
+              /* Ok(reloadAllState(state)) */
+              /* Hashtbl.add(package.nameForPath, path, name);
+                Hashtbl.add(package.pathsForModule, name, Impl(path, Some(path)));
+                Hashtbl.replace(state.packagesByRoot, package.basePath, {
+                  ...package,
+                  localModules: [name, ...package.localModules]
+                });
+                Ok(state) */
+            } else {
+              Ok(state);
+            }
+          };
         } else {
           Ok(state);
         };
-      } else {
-        Ok(state);
-      };
-    },
+      }
+    }
   ),
   (
     "workspace/didChangeConfiguration",
@@ -62,18 +72,34 @@ let notificationHandlers:
     "textDocument/didChange",
     (state, params) => {
       open InfixResult;
-      let%try doc = params |> RJson.get("textDocument");
-      let%try uri = RJson.get("uri", doc) |?> RJson.string;
-      let%try uri = Uri2.parse(uri) |> RResult.orError("Not a uri");
-      let%try changes = RJson.get("contentChanges", params) |?> RJson.array;
-      let%try text =
-        List.nth(changes, List.length(changes) - 1)
-        |> RJson.get("text")
-        |?> RJson.string;
-      /* Hmm how do I know if it's modified? */
-      let state = State.updateContents(uri, text, state);
-      Ok(state);
-    },
+      switch (params |> RJson.get("textDocument")) {
+      | Error(e) => Error(e)
+      | Ok(doc) =>
+        switch (RJson.get("uri", doc) |?> RJson.string) {
+        | Error(e) => Error(e)
+        | Ok(uri) =>
+          switch (Uri2.parse(uri) |> RResult.orError("Not a uri")) {
+          | Error(e) => Error(e)
+          | Ok(uri) =>
+            switch (RJson.get("contentChanges", params) |?> RJson.array) {
+            | Error(e) => Error(e)
+            | Ok(changes) =>
+              switch (
+                List.nth(changes, List.length(changes) - 1)
+                |> RJson.get("text")
+                |?> RJson.string
+              ) {
+              | Error(e) => Error(e)
+              | Ok(text) =>
+                /* Hmm how do I know if it's modified? */
+                let state = State.updateContents(uri, text, state);
+                Ok(state);
+              }
+            }
+          }
+        }
+      }
+    }
   ),
   (
     "workspace/didChangeWatchedFiles",

--- a/src/rescript-editor-support/Packages.re
+++ b/src/rescript-editor-support/Packages.re
@@ -50,104 +50,115 @@ let makePathsForModule =
   (pathsForModule, nameForPath);
 };
 
-let newBsPackage = rootPath => {
-  let%try raw = Files.readFileResult(rootPath /+ "bsconfig.json");
-  let config = Json.parse(raw);
+let newBsPackage = rootPath =>
+  switch (Files.readFileResult(rootPath /+ "bsconfig.json")) {
+  | Error(e) => Error(e)
+  | Ok(raw) =>
+    let config = Json.parse(raw);
 
-  Log.log({|📣 📣 NEW BSB PACKAGE 📣 📣|});
-  /* failwith("Wat"); */
-  Log.log("- location: " ++ rootPath);
+    Log.log({|📣 📣 NEW BSB PACKAGE 📣 📣|});
+    /* failwith("Wat"); */
+    Log.log("- location: " ++ rootPath);
 
-  let compiledBase = BuildSystem.getCompiledBase(rootPath);
-  let%try (dependencyDirectories, dependencyModules) =
-    FindFiles.findDependencyFiles(~debug=true, rootPath, config);
-  let%try_wrap compiledBase =
-    compiledBase
-    |> RResult.orError(
-         "You need to run bsb first so that reason-language-server can access the compiled artifacts.\nOnce you've run bsb, restart the language server.",
-       );
+    let compiledBase = BuildSystem.getCompiledBase(rootPath);
+    switch (FindFiles.findDependencyFiles(~debug=true, rootPath, config)) {
+    | Error(e) => Error(e)
+    | Ok((dependencyDirectories, dependencyModules)) =>
+      switch (
+        compiledBase
+        |> RResult.orError(
+             "You need to run bsb first so that reason-language-server can access the compiled artifacts.\nOnce you've run bsb, restart the language server.",
+           )
+      ) {
+      | Error(e) => Error(e)
+      | Ok(compiledBase) =>
+        Ok(
+          {
+            let namespace = FindFiles.getNamespace(config);
+            let localSourceDirs =
+              FindFiles.getSourceDirectories(~includeDev=true, rootPath, config);
+            Log.log(
+              "Got source directories " ++ String.concat(" - ", localSourceDirs),
+            );
+            let localModules =
+              FindFiles.findProjectFiles(
+                ~debug=true,
+                namespace,
+                rootPath,
+                localSourceDirs,
+                compiledBase,
+              );
+            /* |> List.map(((name, paths)) => (switch (namespace) {
+            | None => name
+            | Some(n) => name ++ "-" ++ n }, paths)); */
+            Log.log(
+              "-- All local modules found: "
+              ++ string_of_int(List.length(localModules)),
+            );
+            localModules
+            |> List.iter(((name, paths)) => {
+                 Log.log(name);
+                 switch (paths) {
+                 | SharedTypes.Impl(cmt, _) => Log.log("impl " ++ cmt)
+                 | Intf(cmi, _) => Log.log("intf " ++ cmi)
+                 | _ => Log.log("Both")
+                 };
+               });
 
-  let namespace = FindFiles.getNamespace(config);
-  let localSourceDirs =
-    FindFiles.getSourceDirectories(~includeDev=true, rootPath, config);
-  Log.log(
-    "Got source directories " ++ String.concat(" - ", localSourceDirs),
-  );
-  let localModules =
-    FindFiles.findProjectFiles(
-      ~debug=true,
-      namespace,
-      rootPath,
-      localSourceDirs,
-      compiledBase,
-    );
-  /* |> List.map(((name, paths)) => (switch (namespace) {
-     | None => name
-     | Some(n) => name ++ "-" ++ n }, paths)); */
-  Log.log(
-    "-- All local modules found: "
-    ++ string_of_int(List.length(localModules)),
-  );
-  localModules
-  |> List.iter(((name, paths)) => {
-       Log.log(name);
-       switch (paths) {
-       | SharedTypes.Impl(cmt, _) => Log.log("impl " ++ cmt)
-       | Intf(cmi, _) => Log.log("intf " ++ cmi)
-       | _ => Log.log("Both")
-       };
-     });
+            let (pathsForModule, nameForPath) =
+              makePathsForModule(localModules, dependencyModules);
 
-  let (pathsForModule, nameForPath) =
-    makePathsForModule(localModules, dependencyModules);
+            let opens =
+              switch (namespace) {
+              | None => []
+              | Some(namespace) =>
+                let cmt = compiledBase /+ namespace ++ ".cmt";
+                Log.log("############ Namespaced as " ++ namespace ++ " at " ++ cmt);
+                Hashtbl.add(pathsForModule, namespace, Impl(cmt, None));
+                [FindFiles.nameSpaceToName(namespace)];
+              };
+            Log.log("Dependency dirs " ++ String.concat(" ", dependencyDirectories));
 
-  let opens =
-    switch (namespace) {
-    | None => []
-    | Some(namespace) =>
-      let cmt = compiledBase /+ namespace ++ ".cmt";
-      Log.log("############ Namespaced as " ++ namespace ++ " at " ++ cmt);
-      Hashtbl.add(pathsForModule, namespace, Impl(cmt, None));
-      [FindFiles.nameSpaceToName(namespace)];
-    };
-  Log.log("Dependency dirs " ++ String.concat(" ", dependencyDirectories));
-
-  let opens = {
-    let flags =
-      MerlinFile.getFlags(rootPath)
-      |> RResult.withDefault([""])
-      |> List.map(escapePreprocessingFlags);
-    let opens =
-      List.fold_left(
-        (opens, item) => {
-          let parts = Utils.split_on_char(' ', item);
-          let rec loop = items =>
-            switch (items) {
-            | ["-open", name, ...rest] => [name, ...loop(rest)]
-            | [_, ...rest] => loop(rest)
-            | [] => []
+            let opens = {
+              let flags =
+                MerlinFile.getFlags(rootPath)
+                |> RResult.withDefault([""])
+                |> List.map(escapePreprocessingFlags);
+              let opens =
+                List.fold_left(
+                  (opens, item) => {
+                    let parts = Utils.split_on_char(' ', item);
+                    let rec loop = items =>
+                      switch (items) {
+                      | ["-open", name, ...rest] => [name, ...loop(rest)]
+                      | [_, ...rest] => loop(rest)
+                      | [] => []
+                      };
+                    opens @ loop(parts);
+                  },
+                  opens,
+                  flags,
+                );
+              opens;
             };
-          opens @ loop(parts);
-        },
-        opens,
-        flags,
-      );
-    opens;
-  };
 
-  let interModuleDependencies = Hashtbl.create(List.length(localModules));
+            let interModuleDependencies = Hashtbl.create(List.length(localModules));
 
-  {
-    rootPath,
-    localModules: localModules |> List.map(fst),
-    dependencyModules: dependencyModules |> List.map(fst),
-    pathsForModule,
-    nameForPath,
-    opens,
-    namespace,
-    interModuleDependencies,
+            {
+              rootPath,
+              localModules: localModules |> List.map(fst),
+              dependencyModules: dependencyModules |> List.map(fst),
+              pathsForModule,
+              nameForPath,
+              opens,
+              namespace,
+              interModuleDependencies,
+            };
+          },
+        )
+      }
+    };
   };
-};
 
 let findRoot = (~uri, packagesByRoot) => {
   let path = Uri2.toPath(uri);
@@ -173,25 +184,34 @@ let getPackage = (~uri, state) =>
       ),
     );
   } else {
-    let%try root =
+    switch (
       findRoot(~uri, state.packagesByRoot)
-      |> RResult.orError("No root directory found");
-    let%try package =
-      switch (root) {
-      | `Root(rootPath) =>
-        Hashtbl.replace(state.rootForUri, uri, rootPath);
-        Ok(
-          Hashtbl.find(
-            state.packagesByRoot,
-            Hashtbl.find(state.rootForUri, uri),
-          ),
-        );
-      | `Bs(rootPath) =>
-        let%try package = newBsPackage(rootPath);
-        Hashtbl.replace(state.rootForUri, uri, package.rootPath);
-        Hashtbl.replace(state.packagesByRoot, package.rootPath, package);
-        Ok(package);
-      };
-
-    Ok(package);
+      |> RResult.orError("No root directory found")
+    ) {
+    | Error(e) => Error(e)
+    | Ok(root) =>
+      switch (
+        switch (root) {
+        | `Root(rootPath) =>
+          Hashtbl.replace(state.rootForUri, uri, rootPath);
+          Ok(
+            Hashtbl.find(
+              state.packagesByRoot,
+              Hashtbl.find(state.rootForUri, uri),
+            ),
+          );
+        | `Bs(rootPath) =>
+          switch (newBsPackage(rootPath)) {
+          | Error(e) => Error(e)
+          | Ok(package) =>
+            Hashtbl.replace(state.rootForUri, uri, package.rootPath);
+            Hashtbl.replace(state.packagesByRoot, package.rootPath, package);
+            Ok(package);
+          }
+        }
+      ) {
+      | Error(e) => Error(e)
+      | Ok(package) => Ok(package)
+      }
+    };
   };

--- a/src/rescript-editor-support/Process_406.re
+++ b/src/rescript-editor-support/Process_406.re
@@ -1,15 +1,18 @@
 open SharedTypes;
 
-let fileForCmt = (~moduleName, ~uri, cmt, processDoc) => {
-  let%try infos = Shared.tryReadCmt(cmt);
-  Ok(ProcessCmt.forCmt(~moduleName, ~uri, processDoc, infos));
-};
+let fileForCmt = (~moduleName, ~uri, cmt, processDoc) =>
+  switch (Shared.tryReadCmt(cmt)) {
+  | Error(e) => Error(e)
+  | Ok(infos) => Ok(ProcessCmt.forCmt(~moduleName, ~uri, processDoc, infos))
+  };
 
-let fullForCmt = (~moduleName, ~uri, cmt, processDoc) => {
-  let%try infos = Shared.tryReadCmt(cmt);
-  let file = ProcessCmt.forCmt(~moduleName, ~uri, processDoc, infos);
-  let extra = ProcessExtra.forCmt(~file, infos);
-  Ok({file, extra});
-};
+let fullForCmt = (~moduleName, ~uri, cmt, processDoc) =>
+  switch (Shared.tryReadCmt(cmt)) {
+  | Error(e) => Error(e)
+  | Ok(infos) =>
+    let file = ProcessCmt.forCmt(~moduleName, ~uri, processDoc, infos);
+    let extra = ProcessExtra.forCmt(~file, infos);
+    Ok({file, extra});
+  };
 
 module PrintType = PrintType;

--- a/src/rescript-editor-support/RescriptEditorSupport.re
+++ b/src/rescript-editor-support/RescriptEditorSupport.re
@@ -25,44 +25,47 @@ let capabilities =
 
 let getInitialState = params => {
   let rootUri = Json.get("rootUri", params) |?> Json.string |?> Uri2.parse;
-  let%try rootUri = rootUri |> RResult.orError("Not a uri");
-  let rootPath = Uri2.toPath(rootUri);
+  switch (rootUri |> RResult.orError("Not a uri")) {
+  | Error(e) => Error(e)
+  | Ok(rootUri) =>
+    let rootPath = Uri2.toPath(rootUri);
 
-  Files.mkdirp(rootPath /+ "node_modules" /+ ".lsp");
-  Log.setLocation(rootPath /+ "node_modules" /+ ".lsp" /+ "debug.log");
-  Log.log("Hello - from " ++ Sys.executable_name);
+    Files.mkdirp(rootPath /+ "node_modules" /+ ".lsp");
+    Log.setLocation(rootPath /+ "node_modules" /+ ".lsp" /+ "debug.log");
+    Log.log("Hello - from " ++ Sys.executable_name);
 
-  Rpc.sendNotification(
-    stdout,
-    "client/registerCapability",
-    J.o([
-      (
-        "registrations",
-        J.l([
-          J.o([
-            ("id", J.s("watching")),
-            ("method", J.s("workspace/didChangeWatchedFiles")),
-            (
-              "registerOptions",
-              J.o([
-                (
-                  "watchers",
-                  J.l([
-                    J.o([("globPattern", J.s("**/bsconfig.json"))]),
-                    J.o([("globPattern", J.s("**/.merlin"))]),
-                  ]),
-                ),
-              ]),
-            ),
+    Rpc.sendNotification(
+      stdout,
+      "client/registerCapability",
+      J.o([
+        (
+          "registrations",
+          J.l([
+            J.o([
+              ("id", J.s("watching")),
+              ("method", J.s("workspace/didChangeWatchedFiles")),
+              (
+                "registerOptions",
+                J.o([
+                  (
+                    "watchers",
+                    J.l([
+                      J.o([("globPattern", J.s("**/bsconfig.json"))]),
+                      J.o([("globPattern", J.s("**/.merlin"))]),
+                    ]),
+                  ),
+                ]),
+              ),
+            ]),
           ]),
-        ]),
-      ),
-    ]),
-  );
+        ),
+      ]),
+    );
 
-  let state = TopTypes.empty();
+    let state = TopTypes.empty();
 
-  Ok(state);
+    Ok(state);
+  };
 };
 
 let parseArgs = args => {


### PR DESCRIPTION
- Convert Hover to unmonad
- Convert MessengerHandlers to unmonad
- Convert NotificationHandlers to unmonad
- Convert Packages to unmonad
- Convert Process_406 to unmonad
- Convert ProcessExtra to unmonad
- Convert Protocol to unmonad
- Convert NewCompletions to unmonad
- Convert Query to unmonad
- Convert References to unmonad
- Convert RescriptEditorSupport.re to unmonad
- Convert State over to unmonad

@cristianoc I've made a commit per file and will do a rebase merge instead of the usual squash merge, so that you can bisect in case some conversion went wrong.

This diff should be read with whitespace sensitivity turned off. The option is in the diff view

