### PR TITLE
Improve code for pipe autocomplete.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 - Don't show file path on hover.
 - Add autocomplete for props in JSX components.
 - Autocomplete: fix issue where `->` autocomplete was overruling `.`. See https://github.com/rescript-lang/rescript-editor-support/issues/99.
+- Add pipe autocomplete for builtin list, array, string, option types. And for string and array literals.
 
 ## Release 1.0.6 of rescript-vscode
 This [commit](https://github.com/rescript-lang/rescript-editor-support/commit/03ee0d97b250474028d4fb08eac81ddb21ccb082) is vendored in [rescript-vscode 1.0.6](https://github.com/rescript-lang/rescript-vscode/releases/tag/1.0.6).

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -79,25 +79,25 @@ let testRecordFields = (gr: gr) => {
 }
 
 @ocaml.doc("vr docstring")
-type vr = | V1 | V2
+type vr = V1 | V2
 
 let v1 = V1
 
 module DoubleNested = ModuleWithDocComment.Nested.NestedAgain
 
-let uncurried = (. x) => x+1;
+let uncurried = (. x) => x + 1
 
 module Inner = {
-  type tInner = int;
+  type tInner = int
   let vInner = 34
 }
 
-type typeInner = Inner.tInner;
+type typeInner = Inner.tInner
 
-let valueInner = Inner.vInner;
+let valueInner = Inner.vInner
 
 @ocaml.doc("Doc comment for functionWithTypeAnnotation")
-let functionWithTypeAnnotation : unit => int = () => 1
+let functionWithTypeAnnotation: unit => int = () => 1
 
 module HoverInsideModuleWithComponent = {
   let x = 2 // check that hover on x works
@@ -111,14 +111,12 @@ module Lib = {
   let next = (~number=0, ~year) => number + year
 }
 
-@ocaml.doc("This module is commented")
-@deprecated("This module is deprecated")
-module Dep : {
-  @ocaml.doc("Some doc comment")
-  @deprecated("Use customDouble instead")
-  let customDouble : int => int
+@ocaml.doc("This module is commented") @deprecated("This module is deprecated")
+module Dep: {
+  @ocaml.doc("Some doc comment") @deprecated("Use customDouble instead")
+  let customDouble: int => int
 
-  let customDouble2 : int => int
+  let customDouble2: int => int
 } = {
   let customDouble = foo => foo * 2
   let customDouble2 = foo => foo * 2
@@ -129,8 +127,12 @@ let cc = Dep.customDouble(11)
 module O = {
   module Comp = {
     @react.component
-    let make = (~first="", ~kas=11, ~foo=3, ~second, ~v) => React.string(first ++ second ++ string_of_int(foo))
+    let make = (~first="", ~kas=11, ~foo=3, ~second, ~v) =>
+      React.string(first ++ second ++ string_of_int(foo))
   }
 }
 
 let comp = <O.Comp key="12" second="abcc" v=12 />
+
+let lll = List.make(3, 4)
+

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -140,3 +140,6 @@ let abc = "abc"
 
 let arr = [1, 2, 3]
 
+let some7 = Some(7)
+
+

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -138,3 +138,5 @@ let lll = List.make(3, 4)
 
 let abc = "abc"
 
+let arr = [1, 2, 3]
+

--- a/examples/example-project/src/ZZ.res
+++ b/examples/example-project/src/ZZ.res
@@ -136,3 +136,5 @@ let comp = <O.Comp key="12" second="abcc" v=12 />
 
 let lll = List.make(3, 4)
 
+let abc = "abc"
+

--- a/src/NewCompletions.ml
+++ b/src/NewCompletions.ml
@@ -516,6 +516,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
              ~detail:(detail name item) ~docstring ~uri ~pos_lnum)
   | Cpipe (pipe, partialName) -> (
     let arrayModulePath = ["Js"; "Array2"] in
+    let listModulePath = ["Belt"; "List"] in
     let optionModulePath = ["Belt"; "Option"] in
     let stringModulePath = ["Js"; "String2"] in
     let getModulePath path =
@@ -527,6 +528,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
       in
       match path with
       | Path.Pident id when Ident.name id = "array" -> arrayModulePath
+      | Path.Pident id when Ident.name id = "list" -> listModulePath
       | Path.Pident id when Ident.name id = "option" -> optionModulePath
       | Path.Pident id when Ident.name id = "string" -> stringModulePath
       | _ -> ( match loop path with _ :: rest -> List.rev rest | [] -> [])

--- a/src/NewCompletions.ml
+++ b/src/NewCompletions.ml
@@ -516,6 +516,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
              ~detail:(detail name item) ~docstring ~uri ~pos_lnum)
   | Cpipe (pipe, partialName) -> (
     let arrayModulePath = ["Js"; "Array2"] in
+    let optionModulePath = ["Belt"; "Option"] in
     let stringModulePath = ["Js"; "String2"] in
     let getModulePath path =
       let rec loop (path : Path.t) =
@@ -525,8 +526,9 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
         | Papply _ -> []
       in
       match path with
-      | Path.Pident id when Ident.name id = "string" -> stringModulePath
       | Path.Pident id when Ident.name id = "array" -> arrayModulePath
+      | Path.Pident id when Ident.name id = "option" -> optionModulePath
+      | Path.Pident id when Ident.name id = "string" -> stringModulePath
       | _ -> ( match loop path with _ :: rest -> List.rev rest | [] -> [])
     in
     let getLhsPath ~pipeId ~partialName =

--- a/src/NewCompletions.ml
+++ b/src/NewCompletions.ml
@@ -514,7 +514,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
          ->
            mkItem ~name ~kind:(kindToInt item) ~deprecated
              ~detail:(detail name item) ~docstring ~uri ~pos_lnum)
-  | Cpipe (lhs, partialName) -> (
+  | Cpipe (pipe, partialName) -> (
     let getModulePath path =
       let rec loop (path : Path.t) =
         match path with
@@ -524,8 +524,8 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
       in
       match loop path with _ :: rest -> List.rev rest | [] -> []
     in
-    let getLhsPath ~lhs ~partialName =
-      match [lhs] |> findItems ~exact:true with
+    let getLhsPath ~pipeId ~partialName =
+      match [pipeId] |> findItems ~exact:true with
       | (_uri, {SharedTypes.item = Value t}) :: _ ->
         let modulePath =
           match t.desc with
@@ -536,7 +536,11 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
         Some (modulePath, partialName)
       | _ -> None
     in
-    let lhsPath = getLhsPath ~lhs ~partialName in
+    let lhsPath =
+      match pipe with
+      | PipeId pipeId -> getLhsPath ~pipeId ~partialName
+      | PipeString -> Some (["Js"; "String2"], partialName)
+    in
     let removePackageOpens modulePath =
       match modulePath with
       | toplevel :: rest when package.TopTypes.opens |> List.mem toplevel ->

--- a/src/NewCompletions.ml
+++ b/src/NewCompletions.ml
@@ -514,7 +514,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
          ->
            mkItem ~name ~kind:(kindToInt item) ~deprecated
              ~detail:(detail name item) ~docstring ~uri ~pos_lnum)
-  | Cpipe s -> (
+  | Cpipe (lhs, partialName) -> (
     let getModulePath path =
       let rec loop (path : Path.t) =
         match path with
@@ -536,14 +536,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
         Some (modulePath, partialName)
       | _ -> None
     in
-    let lhsPath =
-      match Str.split (Str.regexp_string "->") s with
-      | [lhs] -> getLhsPath ~lhs ~partialName:""
-      | [lhs; partialName] -> getLhsPath ~lhs ~partialName
-      | _ ->
-        (* Only allow one -> *)
-        None
-    in
+    let lhsPath = getLhsPath ~lhs ~partialName in
     let removePackageOpens modulePath =
       match modulePath with
       | toplevel :: rest when package.TopTypes.opens |> List.mem toplevel ->

--- a/src/NewCompletions.ml
+++ b/src/NewCompletions.ml
@@ -515,6 +515,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
            mkItem ~name ~kind:(kindToInt item) ~deprecated
              ~detail:(detail name item) ~docstring ~uri ~pos_lnum)
   | Cpipe (pipe, partialName) -> (
+    let arrayModulePath = ["Js"; "Array2"] in
     let stringModulePath = ["Js"; "String2"] in
     let getModulePath path =
       let rec loop (path : Path.t) =
@@ -525,6 +526,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
       in
       match path with
       | Path.Pident id when Ident.name id = "string" -> stringModulePath
+      | Path.Pident id when Ident.name id = "array" -> arrayModulePath
       | _ -> ( match loop path with _ :: rest -> List.rev rest | [] -> [])
     in
     let getLhsPath ~pipeId ~partialName =
@@ -543,6 +545,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
       match pipe with
       | PipeId pipeId -> getLhsPath ~pipeId ~partialName
       | PipeString -> Some (stringModulePath, partialName)
+      | PipeArray -> Some (arrayModulePath, partialName)
     in
     let removePackageOpens modulePath =
       match modulePath with

--- a/src/NewCompletions.ml
+++ b/src/NewCompletions.ml
@@ -515,6 +515,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
            mkItem ~name ~kind:(kindToInt item) ~deprecated
              ~detail:(detail name item) ~docstring ~uri ~pos_lnum)
   | Cpipe (pipe, partialName) -> (
+    let stringModulePath = ["Js"; "String2"] in
     let getModulePath path =
       let rec loop (path : Path.t) =
         match path with
@@ -522,7 +523,9 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
         | Pdot (p, s, _) -> s :: loop p
         | Papply _ -> []
       in
-      match loop path with _ :: rest -> List.rev rest | [] -> []
+      match path with
+      | Path.Pident id when Ident.name id = "string" -> stringModulePath
+      | _ -> ( match loop path with _ :: rest -> List.rev rest | [] -> [])
     in
     let getLhsPath ~pipeId ~partialName =
       match [pipeId] |> findItems ~exact:true with
@@ -539,7 +542,7 @@ let processCompletable ~findItems ~full ~package ~pos ~rawOpens
     let lhsPath =
       match pipe with
       | PipeId pipeId -> getLhsPath ~pipeId ~partialName
-      | PipeString -> Some (["Js"; "String2"], partialName)
+      | PipeString -> Some (stringModulePath, partialName)
     in
     let removePackageOpens modulePath =
       match modulePath with

--- a/src/PartialParser.ml
+++ b/src/PartialParser.ml
@@ -109,7 +109,7 @@ let findJsxContext text offset =
   in
   loop offset
 
-type pipe = PipeId of string | PipeString
+type pipe = PipeId of string | PipeArray | PipeString
 
 type completable =
   | Cdecorator of string  (** e.g. @module *)
@@ -155,6 +155,7 @@ let findCompletable text offset =
         match text.[i] with
         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' -> loop (i - 1)
         | '"' when i == off -> Some PipeString
+        | ']' when i == off -> Some PipeArray
         | _ -> Some (PipeId (String.sub text (i + 1) (off - i))))
     in
     match loop off with

--- a/src/PartialParser.ml
+++ b/src/PartialParser.ml
@@ -145,6 +145,7 @@ let findCompletable text offset =
     | _ -> Cpath parts
   in
   let mkPipe off partialName =
+    let off = skipWhite text off in
     let rec loop i =
       match i < 0 with
       | true -> Some (String.sub text 0 (i - 1))


### PR DESCRIPTION
Use a dedicated code path that takes care of pipe and is separate from normal identifiers.