### PR TITLE
Clean up hover code

### DIFF
--- a/src/Protocol.ml
+++ b/src/Protocol.ml
@@ -1,15 +1,10 @@
-let posOfLexing {Lexing.pos_lnum; pos_cnum; pos_bol} =
-  Json.Object [("line", Json.Number (float_of_int (pos_lnum - 1))); ("character", Json.Number (float_of_int (pos_cnum - pos_bol)))]
-
-let rangeOfLoc {Location.loc_start; loc_end} =
-  Json.Object [("start", posOfLexing loc_start); ("end", posOfLexing loc_end)]
-
 let array l = "[" ^ (String.concat ", " l) ^ "]"
 
 type markupContent = {
   kind: string;
   value: string;
 }
+
 type completionItem = {
   label: string;
   kind: int;
@@ -17,6 +12,11 @@ type completionItem = {
   detail: string;
   documentation: markupContent;
 }
+
+type hover = {
+  contents: string;
+}
+
 let stringifyMarkupContent (m: markupContent) =
   Printf.sprintf {|{"kind": "%s", "value": "%s"}|}
   m.kind (String.escaped m.value)
@@ -34,3 +34,9 @@ let stringifyCompletionItem c =
   (c.tags |> List.map string_of_int |> array)
   (String.escaped c.detail)
   (stringifyMarkupContent c.documentation)
+
+let stringifyHover h =
+  Printf.sprintf {|{"contents": "%s"}|}
+  (String.escaped h.contents)
+
+let null = "null"

--- a/src/RescriptEditorSupport.ml
+++ b/src/RescriptEditorSupport.ml
@@ -43,6 +43,8 @@ let main () =
   | _opts, ["complete"; path; line; char; currentFile] ->
     EditorSupportCommands.complete ~path ~line:(int_of_string line)
       ~char:(int_of_string char) ~currentFile
+  | _opts, ["hover"; path; line; char] ->
+    EditorSupportCommands.hover ~path ~line:(int_of_string line) ~char:(int_of_string char)
   | _ ->
     showHelp ();
     exit 1


### PR DESCRIPTION
This directly returns the right lsp hover payload.

I've modified it from the dump logic, which might still be wanted for testing or such. So this PR might not be merge friendly yet. But I wanna have some feedback first. If we're keeping dump, then I'll modify this diff to add the extra `hover` function instead of overriding dump.